### PR TITLE
[core] fix `path_sep` in global.lua for windows

### DIFF
--- a/lua/core/global.lua
+++ b/lua/core/global.lua
@@ -1,6 +1,5 @@
 local global = {}
 local home = os.getenv("HOME")
-local path_sep = global.is_windows and '\\' or '/'
 local os_name = vim.loop.os_uname().sysname
 
 function global:load_variables()
@@ -8,10 +7,10 @@ function global:load_variables()
     self.is_linux = os_name == 'Linux'
     self.is_windows = os_name == 'Windows'
     self.vim_path = vim.fn.stdpath('config')
+    path_sep = self.is_windows and '\\' or '/'
     self.cache_dir = home .. path_sep .. '.cache' .. path_sep .. 'nvim' ..
                          path_sep
     self.modules_dir = self.vim_path .. path_sep .. 'modules'
-    self.path_sep = path_sep
     self.home = home
     self.data_dir = string.format('%s/site/', vim.fn.stdpath('data'))
 end


### PR DESCRIPTION
Before this, `path_sep` was '/' in windows, which is correct in linux or mac.