### PR TITLE
fix comment-ts-context-commentstring

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -9,7 +9,11 @@ editor['itchyny/vim-cursorword'] = {
 }
 editor['terrortylor/nvim-comment'] = {
     opt = false,
-    config = function() require('nvim_comment').setup() end
+    config = function() require('nvim_comment').setup({
+        hook = function()
+            require("ts_context_commentstring.internal").update_commentstring()
+        end,
+    }) end
 }
 editor['simrat39/symbols-outline.nvim'] = {
     opt = true,


### PR DESCRIPTION
I find the main use nvim-comment no setting

If not setting,the nvim-ts-context-comment is not work

I read origin readme,add the setting to fix this

I try it,now the vue comment can work.