### PR TITLE
fix: missing color property in plugin/nerdline.lua (coc branch)

### DIFF
--- a/plugin/nerdline.lua
+++ b/plugin/nerdline.lua
@@ -13,7 +13,6 @@ local colors = {
     line_bg = '#f0f0f0',
     fg = '#2e3440',
     fg_green = '#8fbcbb',
-
     yellow = '#ebcb8b',
     cyan = '#88c0d0',
     darkblue = '#5e81ac',
@@ -23,8 +22,8 @@ local colors = {
     magenta = '#a626a4',
     blue = '#81a1c1',
     red = '#bf616a',
-
-    mode_bg = '#f0f0f0'
+    mode_bg = '#f0f0f0',
+    violet = '#ee82ee'
 }
 
 local function lsp_status(status)


### PR DESCRIPTION
I found a problem in your nerdline.lua file. When I press `R` in vim (replace mode), the error appears 
`error: attempt to concatenate a nil value; invalid expression: luaeval('require("galaxyline").component_decorator')("VIMode")`

The colors you define with `R` was colors.violet.(line 79 / 80) But in `colors`(line11) :
```
local colors = {
    bg = '#fafafa',
    line_bg = '#f0f0f0',
    fg = '#2e3440',
    fg_green = '#8fbcbb',

    yellow = '#ebcb8b',
    cyan = '#88c0d0',
    darkblue = '#5e81ac',
    green = '#a3be8c',
    orange = '#d08770',
    purple = '#b48ead',
    magenta = '#a626a4',
    blue = '#81a1c1',
    red = '#bf616a',

    mode_bg = '#f0f0f0'
}
```
the `violet` property wasn't defined. So the problem appeared. I added violet property in colors and then the bug fixed.