### PR TITLE
fix clangd switch source header failed

### DIFF
--- a/lua/modules/completion/lspconfig.lua
+++ b/lua/modules/completion/lspconfig.lua
@@ -62,7 +62,7 @@ local function switch_source_header_splitcmd(bufnr, splitcmd)
     bufnr = nvim_lsp.util.validate_bufnr(bufnr)
     local params = {uri = vim.uri_from_bufnr(bufnr)}
     vim.lsp.buf_request(bufnr, 'textDocument/switchSourceHeader', params,
-                        function(err, _, result)
+                        function(err, result)
         if err then error(tostring(err)) end
         if not result then
             print("Corresponding file can’t be determined")


### PR DESCRIPTION
Ref: [lspconfig/clangd.lua](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/clangd.lua)

```lua
-- https://clangd.llvm.org/extensions.html#switch-between-sourceheader
local function switch_source_header(bufnr)
  bufnr = util.validate_bufnr(bufnr)
  local params = { uri = vim.uri_from_bufnr(bufnr) }
  vim.lsp.buf_request(
    bufnr,
    'textDocument/switchSourceHeader',
    params,
    util.compat_handler(function(err, result)
      if err then
        error(tostring(err))
      end
      if not result then
        print 'Corresponding file cannot be determined'
        return
      end
      vim.api.nvim_command('edit ' .. vim.uri_to_fname(result))
    end)
  )
end
```