### PR TITLE
fix symbols-outline wide error

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -3,11 +3,11 @@ local dap_dir = vim.fn.stdpath("data") .. "/dapinstall/"
 local sessions_dir = vim.fn.stdpath("data") .. "/sessions/"
 
 function config.symbols_outline()
-    vim.g.symbols_outline = {
+    require"symbols-outline".setup({
         highlight_hovered_item = true,
         show_guides = true,
         auto_preview = true,
-        position = "right",
+        position = "left",
         show_numbers = false,
         show_relative_numbers = false,
         show_symbol_details = true,
@@ -48,7 +48,7 @@ function config.symbols_outline()
             Operator = {icon = "+", hl = "TSOperator"},
             TypeParameter = {icon = "𝙏", hl = "TSParameter"}
         }
-    }
+    })
 end
 
 function config.vim_cursorwod()


### PR DESCRIPTION
Minimap causes the symbol list to display abnormally, adjust to the left。

or just fix symbol-outline config not take effect. 

REF:[issue](https://github.com/simrat39/symbols-outline.nvim/issues/62)