### PR TITLE
fix (/lua/modules/completion/plugins.lua) cmp-tmux name

### DIFF
--- a/lua/modules/completion/plugins.lua
+++ b/lua/modules/completion/plugins.lua
@@ -25,8 +25,8 @@ completion["hrsh7th/nvim-cmp"] = {
         {"saadparwaiz1/cmp_luasnip", after = "LuaSnip"},
         {"hrsh7th/cmp-nvim-lsp", after = "cmp_luasnip"},
         {"hrsh7th/cmp-nvim-lua", after = "cmp-nvim-lsp"},
-        {"andersevenrud/compe-tmux", branch = "cmp", after = "cmp-nvim-lua"},
-        {"hrsh7th/cmp-path", after = "compe-tmux"},
+        {"andersevenrud/cmp-tmux", after = "cmp-nvim-lua"},
+        {"hrsh7th/cmp-path", after = "cmp-tmux"},
         {"f3fora/cmp-spell", after = "cmp-path"},
         {"hrsh7th/cmp-buffer", after = "cmp-spell"},
         {"kdheepak/cmp-latex-symbols", after = "cmp-buffer"}


### PR DESCRIPTION
Author of neovim plugin andersevenrud/cmp-tmux has changed the main branch from compe-tmux to cmp-tmux. Therefore, it is necessary to make some change for PackerSync to work as expected.