### PR TITLE
修复：lua 语言服务器无法正确识别和加载 `lspconfig` 传入的设置

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,7 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-    "Lua.diagnostics.globals": [
-        "vim",
-        "packer_plugins"
-    ]
-}

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -123,7 +123,7 @@ for _, server in ipairs(lsp_installer.get_installed_servers()) do
 				client.resolved_capabilities.document_formatting = false
 				custom_attach(client)
 			end,
-			setttings = {
+			settings = {
 				Lua = {
 					diagnostics = { globals = { "vim", "packer_plugins" } },
 					workspace = {


### PR DESCRIPTION
原因是传入设置的时候 `settings` 打成了 `setttings` ww