### PR TITLE
feat: Add brglng/vim-im-select to change input method automatically.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -360,4 +360,20 @@ function config.tabout()
 	})
 end
 
+function config.imselect()
+	-- fcitx5 need a manual config
+	if vim.fn.executable("fcitx5-remote") == 1 then
+		vim.cmd([[
+		let g:im_select_get_im_cmd = ["fcitx5-remote"]
+		let g:im_select_default = '1'
+		let g:ImSelectSetImCmd = {
+			\ key ->
+			\ key == 1 ? ['fcitx5-remote', '-c'] :
+			\ key == 2 ? ['fcitx5-remote', '-o'] :
+			\ execute("throw 'invalid im key'")
+			\ }
+			]])
+	end
+end
+
 return config

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -134,5 +134,10 @@ editor["sindrets/diffview.nvim"] = {
 	opt = true,
 	cmd = { "DiffviewOpen" },
 }
+editor["brglng/vim-im-select"] = {
+	opt = false,
+	event = "BufReadPost",
+	config = conf.imselect,
+}
 
 return editor


### PR DESCRIPTION
related issue: #112 

have tested on my Linux (with `fcitx5` installed) and MacOS (need install `im-select` first)