### PR TITLE
fix: Add file_browser extension and fix colorscheme conflict

### DIFF
--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -6,6 +6,7 @@ function config.telescope()
 	vim.cmd([[packadd telescope-project.nvim]])
 	vim.cmd([[packadd telescope-frecency.nvim]])
 	vim.cmd([[packadd telescope-zoxide]])
+	vim.cmd([[packadd telescope-file-browser.nvim]])
 
 	require("telescope").setup({
 		defaults = {
@@ -50,6 +51,7 @@ function config.telescope()
 	require("telescope").load_extension("project")
 	require("telescope").load_extension("zoxide")
 	require("telescope").load_extension("frecency")
+	require("telescope").load_extension("file_browser")
 end
 
 function config.trouble()

--- a/lua/modules/tools/plugins.lua
+++ b/lua/modules/tools/plugins.lua
@@ -28,6 +28,10 @@ tools["nvim-telescope/telescope-frecency.nvim"] = {
 	requires = { { "tami5/sqlite.lua", opt = true } },
 }
 tools["jvgrootveld/telescope-zoxide"] = { opt = true, after = "telescope-frecency.nvim" }
+tools["nvim-telescope/telescope-file-browser.nvim"] = {
+	opt = true,
+	after = "telescope-zoxide",
+}
 tools["michaelb/sniprun"] = {
 	opt = true,
 	run = "bash ./install.sh",

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -57,7 +57,6 @@ function config.alpha()
 			opts = opts,
 		}
 	end
-
 	local leader = "comma"
 	dashboard.section.buttons.val = {
 		button("comma s c", " Scheme change", leader, "<cmd>Telescope colorscheme<cr>"),
@@ -83,7 +82,6 @@ function config.alpha()
 			.. total_plugins
 			.. " plugins"
 	end
-
 	dashboard.section.footer.val = footer()
 	dashboard.section.footer.opts.hl = "Function"
 
@@ -105,7 +103,7 @@ function config.alpha()
 end
 
 function config.edge()
-	vim.cmd([[set background=light]])
+	-- vim.cmd([[set background=light]])
 	vim.g.edge_style = "aura"
 	vim.g.edge_enable_italic = 1
 	vim.g.edge_disable_italic_comment = 1
@@ -120,7 +118,8 @@ function config.nord()
 	vim.g.nord_cursorline_transparent = true
 	vim.g.nord_disable_background = false
 	vim.g.nord_enable_sidebar_background = true
-	vim.g.nord_italic = false
+	vim.g.nord_italic = true
+	require("nord").set()
 end
 
 function config.catppuccin()
@@ -213,7 +212,6 @@ function config.lualine()
 			return ""
 		end
 	end
-
 	local mini_sections = {
 		lualine_a = {},
 		lualine_b = {},
@@ -562,8 +560,6 @@ function config.gitsigns()
 end
 
 function config.indent_blankline()
-	vim.opt.termguicolors = true
-	vim.opt.list = true
 	require("indent_blankline").setup({
 		char = "│",
 		show_first_indent_level = true,


### PR DESCRIPTION
## colorscheme conflict
I'm not sure if this is a bug. In `config.edge()` there is one line to set a light background:
```
vim.cmd([[set background=light]])
```

This line would break settings in `nord` and give a weird color scheme when you switch to `nord`.

## redundant config?
I guess in `config.indent_blankline()` the following lines are redundant? 
```
vim.opt.termguicolors = true
vim.opt.list = true
```

## Add missing dependency
`nvim-telescope/telescope-file-browser.nvim` is needed in key-mapping. Again, I'm not sure whether I should add it back 😉