### PR TITLE
fix: disable completion by vim-go, use `gopls -remote=auto` for lsp

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -67,6 +67,7 @@ for _, server in ipairs(lsp_installer.get_installed_servers()) do
 			on_attach = custom_attach,
 			flags = { debounce_text_changes = 500 },
 			capabilities = capabilities,
+			cmd = { "gopls", "-remote=auto" },
 			settings = {
 				gopls = {
 					usePlaceholders = true,

--- a/lua/modules/lang/config.lua
+++ b/lua/modules/lang/config.lua
@@ -74,8 +74,9 @@ function config.rust_tools()
 end
 
 function config.lang_go()
-	vim.g.go_doc_keywordprg_enabled = false
-	vim.g.go_def_mapping_enabled = false
+	vim.g.go_doc_keywordprg_enabled = 0
+	vim.g.go_def_mapping_enabled = 0
+	vim.g.go_code_completion_enabled = 0
 end
 
 -- function config.lang_org()


### PR DESCRIPTION
Tell `lspconfig` to use `gopls -remote=auto` to avoid spawning two `gopls` server processes. (One by `LSP` and another by `vim-go`)