### PR TITLE
fix: incsearch compared with wilder cause highlight flicker

### DIFF
--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -145,7 +145,7 @@ function config.which_key()
 		},
 
 		window = {
-			border = "none", 
+			border = "none",
 			position = "bottom",
 			margin = { 1, 0, 1, 0 },
 			padding = { 1, 1, 1, 1 },
@@ -158,8 +158,22 @@ function config.wilder()
 	vim.cmd([[
 call wilder#setup({'modes': [':', '/', '?']})
 call wilder#set_option('use_python_remote_plugin', 0)
-call wilder#set_option('pipeline', [wilder#branch(wilder#cmdline_pipeline({'use_python': 0,'fuzzy': 1, 'fuzzy_filter': wilder#lua_fzy_filter()}),wilder#vim_search_pipeline(), [wilder#check({_, x -> empty(x)}), wilder#history(), wilder#result({'draw': [{_, x -> ' ' . x}]})])])
-call wilder#set_option('renderer', wilder#renderer_mux({':': wilder#popupmenu_renderer({'highlighter': wilder#lua_fzy_highlighter(), 'left': [wilder#popupmenu_devicons()], 'right': [' ', wilder#popupmenu_scrollbar()]}), '/': wilder#wildmenu_renderer({'highlighter': wilder#lua_fzy_highlighter()})}))
+call wilder#set_option('pipeline', [wilder#branch(
+	\ wilder#cmdline_pipeline({'use_python': 0,'fuzzy': 1, 'fuzzy_filter': wilder#lua_fzy_filter()}),
+	\ wilder#vim_search_pipeline(),
+	\ [wilder#check({_, x -> empty(x)}), wilder#history(), wilder#result({'draw': [{_, x -> ' ' . x}]})]
+	\ )])
+call wilder#set_option('renderer', wilder#renderer_mux({
+	\ ':': wilder#popupmenu_renderer({
+		\ 'highlighter': wilder#lua_fzy_highlighter(),
+		\ 'left': [wilder#popupmenu_devicons()],
+		\ 'right': [' ', wilder#popupmenu_scrollbar()]
+		\ }),
+	\ '/': wilder#wildmenu_renderer({
+		\ 'highlighter': wilder#lua_fzy_highlighter(),
+		\ 'apply_incsearch_fix': v:true,
+		\})
+	\ }))
 ]])
 end
 


### PR DESCRIPTION
Related issue: https://github.com/gelguy/wilder.nvim/issues/105 :

> I am afraid it might be related to [28b26ff](https://github.com/gelguy/wilder.nvim/commit/28b26ffa8c3a8bdc34e00bc971199d1bfba30c8f). After adding
> 
> ```viml
>     \   'apply_incsearch_fix': v:true,
> ```
> 
> in the config for `wildmenu_renderer` (see commit [Gelio/ubuntu-dotfiles@cf03f95](https://github.com/Gelio/ubuntu-dotfiles/commit/cf03f95a482ce2b5bda9b5f70eb8e822c025fba1)), the flickering is gone.

**This method has a DRAWBACK** which is described in `wilder`'s README:

> ### Cannot scroll through `/`-search history with `<Up>` or `<Down>`
>
> A workaround was added for https://github.com/gelguy/wilder.nvim/issues/30.
> This workaround breaks the `/` history when using the `wilder#wildmenu_renderer()`.