### PR TITLE
WIP: feat: Add brglng/vim-im-select, fix exception on fcitx5 being closed

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -360,4 +360,21 @@ function config.tabout()
 	})
 end
 
+function config.imselect()
+	-- fcitx5 need a manual config
+	if vim.fn.executable("fcitx5-remote") == 1 then
+		vim.cmd([[
+		let g:im_select_get_im_cmd = ["fcitx5-remote"]
+		let g:im_select_default = '1'
+		let g:ImSelectSetImCmd = {
+			\ key ->
+			\ key == 1 ? ['fcitx5-remote', '-c'] :
+			\ key == 2 ? ['fcitx5-remote', '-o'] :
+			\ key == 0 ? ['fcitx5-remote', '-c'] :
+			\ execute("throw 'invalid im key'")
+			\ }
+			]])
+	end
+end
+
 return config

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -134,5 +134,10 @@ editor["sindrets/diffview.nvim"] = {
 	opt = true,
 	cmd = { "DiffviewOpen" },
 }
+editor["brglng/vim-im-select"] = {
+	opt = false,
+	event = "BufReadPost",
+	config = conf.imselect,
+}
 
 return editor


### PR DESCRIPTION
@ayamir 可以帮测试一下吗，我猜测之前的异常是因为没处理 `0` 的结果，`fcitx5-remote -h` 提示 `0` 表示 fcitx 已关闭。

所以加了一行：如果之前的状态是 fcitx 已退出，再次focus时应该关闭输入法。
```
\ key == 0 ? ['fcitx5-remote', '-c'] :
```