### PR TITLE
Fix (lua/modules/ui/config.lua) Setup configurations of nvim-tree

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -361,38 +361,8 @@ function config.nvim_gps()
 end
 
 function config.nvim_tree()
-	vim.g.root_folder_modifier = ":e"
-	vim.g.icon_padding = " "
-	vim.g.symlink_arror = "  "
-	vim.g.respect_buf_cwd = 1
-
-	vim.g.icons = {
-		["default"] = "", --
-		["symlink"] = "",
-		["git"] = {
-			["unstaged"] = "",
-			["staged"] = "", --
-			["unmerged"] = "שׂ",
-			["renamed"] = "", --
-			["untracked"] = "ﲉ",
-			["deleted"] = "",
-			["ignored"] = "", --◌
-		},
-		["folder"] = {
-			-- ['arrow_open'] = "",
-			-- ['arrow_closed'] = "",
-			["arrow_open"] = "",
-			["arrow_closed"] = "",
-			["default"] = "",
-			["open"] = "",
-			["empty"] = "",
-			["empty_open"] = "",
-			["symlink"] = "",
-			["symlink_open"] = "",
-		},
-	}
-
 	require("nvim-tree").setup({
+		respect_buf_cwd = true,
 		auto_reload_on_write = true,
 		disable_netrw = false,
 		hijack_cursor = true,
@@ -421,6 +391,36 @@ function config.nvim_tree()
 					corner = "└ ",
 					edge = "│ ",
 					none = "  ",
+				},
+			},
+			root_folder_modifier = ":e",
+			icons = {
+				padding = " ",
+				symlink_arrow = "  ",
+				glyphs = {
+					["default"] = "", --
+					["symlink"] = "",
+					["git"] = {
+						["unstaged"] = "",
+						["staged"] = "", --
+						["unmerged"] = "שׂ",
+						["renamed"] = "", --
+						["untracked"] = "ﲉ",
+						["deleted"] = "",
+						["ignored"] = "", --◌
+					},
+					["folder"] = {
+						-- ['arrow_open'] = "",
+						-- ['arrow_closed'] = "",
+						["arrow_open"] = "",
+						["arrow_closed"] = "",
+						["default"] = "",
+						["open"] = "",
+						["empty"] = "",
+						["empty_open"] = "",
+						["symlink"] = "",
+						["symlink_open"] = "",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
如果没理解错的话（ https://github.com/kyazdani42/nvim-tree.lua/issues/674 ）
> nvim-tree.lua once used global variables to define options. These have been moved into **setup options.**

nvim-tree的全局变量`vim.g.`应该迁移到`setup`的表里面（

顺带改了一个拼写错误233（`symlink_arror -> symlink_arrow`）