### PR TITLE
Fix (lua/modules/editor/config.lua) Setup options for dapui

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -167,21 +167,23 @@ function config.dapui()
 			edit = "e",
 			repl = "r",
 		},
-		sidebar = {
-			elements = {
-				-- Provide as ID strings or tables with "id" and "size" keys
-				{
-					id = "scopes",
-					size = 0.25, -- Can be float or integer > 1
+		layouts = {
+			{
+				elements = {
+					-- Provide as ID strings or tables with "id" and "size" keys
+					{
+						id = "scopes",
+						size = 0.25, -- Can be float or integer > 1
+					},
+					{ id = "breakpoints", size = 0.25 },
+					{ id = "stacks", size = 0.25 },
+					{ id = "watches", size = 0.25 },
 				},
-				{ id = "breakpoints", size = 0.25 },
-				{ id = "stacks", size = 0.25 },
-				{ id = "watches", size = 00.25 },
+				size = 40,
+				position = "left",
 			},
-			size = 40,
-			position = "left",
+			{ elements = { "repl" }, size = 10, position = "bottom" },
 		},
-		tray = { elements = { "repl" }, size = 10, position = "bottom" },
 		floating = {
 			max_height = nil,
 			max_width = nil,


### PR DESCRIPTION
[dapui](https://github.com/rcarriga/nvim-dap-ui)的最新版本弃用了`sidebar`和`tray`的选项。在执行`<leader>ps`后将看到：

> The 'sidebar' and 'tray' options are deprecated. Please use ' layouts' instead.

详见[作者示例](https://github.com/rcarriga/nvim-dap-ui/blob/52f4840cb95e6638f18a74b71b536c3bd12e9fd8/README.md?plain=1#L74-L94)