### PR TITLE
Fix (lua/modules/completion/config.lua) Setup options for nvim-autopairs

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -200,7 +200,7 @@ function config.autopairs()
 		"confirm_done",
 		cmp_autopairs.on_confirm_done({
 			filetypes = {
-				-- "*" is a alias to all filetypes
+				-- "*" is an alias to all filetypes
 				["*"] = {
 					["("] = {
 						kind = {

--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -195,8 +195,26 @@ function config.autopairs()
 	-- If you want insert `(` after select function or method item
 	local cmp_autopairs = require("nvim-autopairs.completion.cmp")
 	local cmp = require("cmp")
-	cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done({ map_char = { tex = "" } }))
-	cmp_autopairs.lisp[#cmp_autopairs.lisp + 1] = "racket"
+	local handlers = require("nvim-autopairs.completion.handlers")
+	cmp.event:on(
+		"confirm_done",
+		cmp_autopairs.on_confirm_done({
+			filetypes = {
+				-- "*" is a alias to all filetypes
+				["*"] = {
+					["("] = {
+						kind = {
+							cmp.lsp.CompletionItemKind.Function,
+							cmp.lsp.CompletionItemKind.Method,
+						},
+						handler = handlers["*"],
+					},
+				},
+				-- Disable for tex
+				tex = false,
+			},
+		})
+	)
 end
 
 function config.bqf()


### PR DESCRIPTION
https://github.com/windwp/nvim-autopairs/commit/469ef47fc277e168bfc3e7496442718b2fa1eb1b 调整了部分项目结构。因此更改了设置避免`packer.nvim`报错（例如`cmp_autopairs.lisp`表会是`nil`）