### PR TITLE
Clear neovim python interpreter setting

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -98,7 +98,7 @@ local load_core = function()
 
 	pack.ensure_plugins()
 	neovide_config()
-	check_conda()
+	-- check_conda()
 	-- clipboard_config()
 
 	require("core.options")

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -110,6 +110,9 @@ local function load_options()
 		}
 		vim.g.python_host_prog = "/usr/bin/python"
 		vim.g.python3_host_prog = "/usr/local/bin/python3"
+	else 
+		vim.g.python_host_prog = "/usr/bin/python"
+		vim.g.python3_host_prog = "/usr/bin/python3"
 	end
 	for name, value in pairs(global_local) do
 		vim.o[name] = value


### PR DESCRIPTION
Generally speaking, some packages needed by `neovim` are installed in the system default python environment, but the `check_conda()` function sets the `neovim` python path to the python in the `conda` environment, which can easily cause errors for some plugins.
