### PR TITLE
Fix warning of dap plugins

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -221,6 +221,7 @@ function config.dapui()
 end
 
 function config.dap()
+	local dapui = require("dapui")
 	local dap = require("dap")
 	local dapui = require("dapui")
 

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -221,7 +221,7 @@ function config.dapui()
 end
 
 function config.dap()
-	local dapui = require("dapui")
+	vim.cmd([[packadd nvim-dap-ui]])
 	local dap = require("dap")
 	local dapui = require("dapui")
 

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -83,18 +83,13 @@ editor["max397574/better-escape.nvim"] = {
 	config = conf.better_escape,
 }
 editor["rcarriga/nvim-dap-ui"] = {
-	opt = false,
+	opt = true,
 	config = conf.dapui,
-	requires = {
-		{ "mfussenegger/nvim-dap", config = conf.dap },
-		{
-			"Pocco81/dap-buddy.nvim",
-			opt = true,
-			cmd = { "DIInstall", "DIUninstall", "DIList" },
-			commit = "24923c3819a450a772bb8f675926d530e829665f",
-			config = conf.dapinstall,
-		},
-	},
+}
+editor["mfussenegger/nvim-dap"] = {
+	opt = true,
+	cmd = "DapToggleBreakpoint",
+	config = conf.dap,
 }
 editor["tpope/vim-fugitive"] = { opt = true, cmd = { "Git", "G" } }
 editor["famiu/bufdelete.nvim"] = {


### PR DESCRIPTION
- Delete `dap-buddy` plugin since mason.nvim
- Adjust dap plugins order