### PR TITLE
fix(nvim-dap & dapui): DAP itself and its interdependencies should NOT be lazy-loaded.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -221,7 +221,6 @@ function config.dapui()
 end
 
 function config.dap()
-	vim.cmd([[packadd nvim-dap-ui]])
 	local dap = require("dap")
 	local dapui = require("dapui")
 

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -84,10 +84,9 @@ editor["max397574/better-escape.nvim"] = {
 }
 editor["mfussenegger/nvim-dap"] = {
 	opt = false,
-	config = conf.dap,
 }
 editor["rcarriga/nvim-dap-ui"] = {
-	opt = true,
+	opt = false,
 	config = conf.dapui,
 }
 editor["tpope/vim-fugitive"] = { opt = true, cmd = { "Git", "G" } }

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -84,6 +84,7 @@ editor["max397574/better-escape.nvim"] = {
 }
 editor["mfussenegger/nvim-dap"] = {
 	opt = false,
+	config = conf.dap,
 }
 editor["rcarriga/nvim-dap-ui"] = {
 	opt = false,

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -82,14 +82,13 @@ editor["max397574/better-escape.nvim"] = {
 	event = "BufReadPost",
 	config = conf.better_escape,
 }
+editor["mfussenegger/nvim-dap"] = {
+	opt = false,
+	config = conf.dap,
+}
 editor["rcarriga/nvim-dap-ui"] = {
 	opt = true,
 	config = conf.dapui,
-}
-editor["mfussenegger/nvim-dap"] = {
-	opt = true,
-	cmd = "DapToggleBreakpoint",
-	config = conf.dap,
 }
 editor["tpope/vim-fugitive"] = { opt = true, cmd = { "Git", "G" } }
 editor["famiu/bufdelete.nvim"] = {


### PR DESCRIPTION
- **nvim-dap should not be lazy-loaded, because in keymap:**
https://github.com/ayamir/nvimdots/blob/075764e3cc72f57d348e5f80e4917a6ef50bac2d/lua/keymap/init.lua#L106-L123
  - All settings use lua's `require('dap')` method to call nvim-dap. This implies `:DapToggleBreakpoint` will never be called, and in practice neovim would throw an error. (i.e., `module 'dap' not found`).

- There are two ways to fix this problem - changing the attribute of nvim-dap to `opt = false` is the simplest one, whereas modifying the keymap will force the `cmd` table to list all possible loading methods, which involves a wide range of changes, so the former is implemented.

- Meanwhile, in the previous settings:
https://github.com/ayamir/nvimdots/blob/323f1df0582d61eea1c3fe61f848f9e6035a433d/lua/modules/editor/plugins.lua#L89
  - nvim-dap is not lazy-loaded, which is also the recommended loading method.

- **The same applies to dapui, because the two constitute an interdependent relationship. Note that:**
https://github.com/ayamir/nvimdots/blob/323f1df0582d61eea1c3fe61f848f9e6035a433d/lua/modules/editor/plugins.lua#L85-L89

******

- **nvim-dap不应该设置延迟加载，因为在键绑定中：**
https://github.com/ayamir/nvimdots/blob/075764e3cc72f57d348e5f80e4917a6ef50bac2d/lua/keymap/init.lua#L106-L123
  - 均使用lua的`require('dap')`方法调用nvim-dap。这意味着`:DapToggleBreakpoint`将永远不会被触发，实际测试中也会报错（即：`module 'dap' not found`）。

- 有两种方法可以修复这个问题：更改nvim-dap的属性为`opt = false`是最简单的方法；而如果更改keymap会导致`cmd`表需要列出所有可能的触发方式，涉及大范围的更改，因此选择了前者。

- 同时，在之前的设置中：
https://github.com/ayamir/nvimdots/blob/323f1df0582d61eea1c3fe61f848f9e6035a433d/lua/modules/editor/plugins.lua#L89
  - nvim-dap并没有设置为延迟加载，这也是推荐的加载方式。

- **同理也适用于dapui，因为二者构成了相互依赖的关系。详见：**
https://github.com/ayamir/nvimdots/blob/323f1df0582d61eea1c3fe61f848f9e6035a433d/lua/modules/editor/plugins.lua#L85-L89