### PR TITLE
fix(nvim-dap & dapui): Lazyload and integrations for DAP.

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -82,14 +82,26 @@ editor["max397574/better-escape.nvim"] = {
 	event = "BufReadPost",
 	config = conf.better_escape,
 }
-editor["rcarriga/nvim-dap-ui"] = {
-	opt = true,
-	config = conf.dapui,
-}
 editor["mfussenegger/nvim-dap"] = {
 	opt = true,
-	cmd = "DapToggleBreakpoint",
+	cmd = {
+		"DapSetLogLevel",
+		"DapShowLog",
+		"DapContinue",
+		"DapToggleBreakpoint",
+		"DapToggleRepl",
+		"DapStepOver",
+		"DapStepInto",
+		"DapStepOut",
+		"DapTerminate",
+	},
+	module = "dap",
 	config = conf.dap,
+}
+editor["rcarriga/nvim-dap-ui"] = {
+	opt = true,
+	after = "nvim-dap", -- Need to call setup after dap has been initialized.
+	config = conf.dapui,
 }
 editor["tpope/vim-fugitive"] = { opt = true, cmd = { "Git", "G" } }
 editor["famiu/bufdelete.nvim"] = {


### PR DESCRIPTION
See https://github.com/ayamir/nvimdots/pull/172 for detailed discussion.
The current configuration will **not** affect startup time anymore.