### PR TITLE
Use toggleterm for horizontal,vertical and float terminals, plus lazygit ;)

### DIFF
--- a/lua/keymap/bind.lua
+++ b/lua/keymap/bind.lua
@@ -9,6 +9,7 @@ function rhs_options:new()
 			expr = false,
 			nowait = false,
 		},
+		buffer = false,
 	}
 	setmetatable(instance, self)
 	self.__index = self
@@ -31,6 +32,7 @@ function rhs_options:map_args(cmd_string)
 end
 
 function rhs_options:map_cu(cmd_string)
+	-- <C-u> to eliminate the automatically inserted range in visual mode
 	self.cmd = (":<C-u>%s<CR>"):format(cmd_string)
 	return self
 end
@@ -52,6 +54,11 @@ end
 
 function rhs_options:with_nowait()
 	self.options.nowait = true
+	return self
+end
+
+function rhs_options:with_buffer(num)
+	self.buffer = num
 	return self
 end
 
@@ -83,7 +90,12 @@ function pbind.nvim_load_mapping(mapping)
 		if type(value) == "table" then
 			local rhs = value.cmd
 			local options = value.options
-			vim.api.nvim_set_keymap(mode, keymap, rhs, options)
+			local buf = value.buffer
+			if buf then
+				vim.api.nvim_buf_set_keymap(buf, mode, keymap, rhs, options)
+			else
+				vim.api.nvim_set_keymap(mode, keymap, rhs, options)
+			end
 		end
 	end
 end

--- a/lua/keymap/config.lua
+++ b/lua/keymap/config.lua
@@ -25,3 +25,16 @@ _G.enhance_align = function(key)
 	local map = { ["nga"] = "<Plug>(EasyAlign)", ["xga"] = "<Plug>(EasyAlign)" }
 	return t(map[key])
 end
+
+local _lazygit = nil
+_G.toggle_lazygit = function()
+	if not _lazygit then
+		local Terminal = require("toggleterm.terminal").Terminal
+		_lazygit = Terminal:new({
+			cmd = "lazygit",
+			hidden = true,
+			direction = "float",
+		})
+	end
+	_lazygit:toggle()
+end

--- a/lua/keymap/init.lua
+++ b/lua/keymap/init.lua
@@ -42,13 +42,25 @@ local plug_map = {
 	["n|gd"] = map_cr("Lspsaga preview_definition"):with_noremap():with_silent(),
 	["n|gD"] = map_cr("lua vim.lsp.buf.definition()"):with_noremap():with_silent(),
 	["n|gh"] = map_cr("lua vim.lsp.buf.references()"):with_noremap():with_silent(),
-	["n|<A-d>"] = map_cu('lua require("FTerm").toggle()'):with_noremap():with_silent(),
-	["t|<A-d>"] = map_cu([[<C-\><C-n><CMD>lua require("FTerm").toggle()]]):with_noremap():with_silent(),
-	["t|<A-S-d>"] = map_cu([[<C-\><C-n><CMD>lua require("FTerm").exit()]]):with_noremap():with_silent(),
-	["n|<Leader>g"] = map_cu("lua require('FTerm').run('lazygit')"):with_noremap():with_silent(),
-	["n|<Leader>G"] = map_cu("Git"):with_noremap():with_silent(),
 	["n|gps"] = map_cr("G push"):with_noremap():with_silent(),
 	["n|gpl"] = map_cr("G pull"):with_noremap():with_silent(),
+	-- toggleterm
+	-- ["t|<Esc><Esc>"] = map_cmd([[<C-\><C-n>]]), -- switch to normal mode in terminal.
+	["n|<C-\\>"] = map_cr([[execute v:count . "ToggleTerm direction=horizontal"]]):with_noremap():with_silent(),
+	["i|<C-\\>"] = map_cmd("<Esc><Cmd>ToggleTerm direction=horizontal<CR>"):with_noremap():with_silent(),
+	["t|<C-\\>"] = map_cmd("<Esc><Cmd>ToggleTerm<CR>"):with_noremap():with_silent(),
+	["n|<C-w>t"] = map_cr([[execute v:count . "ToggleTerm direction=vertical"]]):with_noremap():with_silent(),
+	["i|<C-w>t"] = map_cmd("<Esc><Cmd>ToggleTerm direction=vertical<CR>"):with_noremap():with_silent(),
+	["t|<C-w>t"] = map_cmd("<Esc><Cmd>ToggleTerm<CR>"):with_noremap():with_silent(),
+	["n|<F5>"] = map_cr([[execute v:count . "ToggleTerm direction=vertical"]]):with_noremap():with_silent(),
+	["i|<F5>"] = map_cmd("<Esc><Cmd>ToggleTerm direction=vertical<CR>"):with_noremap():with_silent(),
+	["t|<F5>"] = map_cmd("<Esc><Cmd>ToggleTerm<CR>"):with_noremap():with_silent(),
+	["n|<A-d>"] = map_cr([[execute v:count . "ToggleTerm direction=float"]]):with_noremap():with_silent(),
+	["i|<A-d>"] = map_cmd("<Esc><Cmd>ToggleTerm direction=float<CR>"):with_noremap():with_silent(),
+	["t|<A-d>"] = map_cmd("<Esc><Cmd>ToggleTerm<CR>"):with_noremap():with_silent(),
+	["n|<leader>g"] = map_cr("lua toggle_lazygit()"):with_noremap():with_silent(),
+	["t|<leader>g"] = map_cmd("<Esc><Cmd>lua toggle_lazygit()<CR>"):with_noremap():with_silent(),
+	["n|<leader>G"] = map_cu("Git"):with_noremap():with_silent(),
 	-- Plugin trouble
 	["n|gt"] = map_cr("TroubleToggle"):with_noremap():with_silent(),
 	["n|gR"] = map_cr("TroubleToggle lsp_references"):with_noremap():with_silent(),
@@ -92,9 +104,6 @@ local plug_map = {
 	-- Plugin EasyAlign
 	["n|ga"] = map_cmd("v:lua.enhance_align('nga')"):with_expr(),
 	["x|ga"] = map_cmd("v:lua.enhance_align('xga')"):with_expr(),
-	-- Plugin split-term
-	["n|<F5>"] = map_cr("VTerm"):with_noremap():with_silent(),
-	["n|<C-w>t"] = map_cr("VTerm"):with_noremap():with_silent(),
 	-- Plugin MarkdownPreview
 	["n|<F12>"] = map_cr("MarkdownPreviewToggle"):with_noremap():with_silent(),
 	-- Plugin auto_session

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -169,7 +169,7 @@ function config.toggleterm()
 				return vim.o.columns * 0.40
 			end
 		end,
-		open_mapping = [[<c-\>]],
+		open_mapping = false, -- [[<c-\>]],
 		hide_numbers = true, -- hide the number column in toggleterm buffers
 		shade_filetypes = {},
 		shade_terminals = false,

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -60,13 +60,11 @@ editor["karb94/neoscroll.nvim"] = {
 	event = "BufReadPost",
 	config = conf.neoscroll,
 }
-editor["vimlab/split-term.vim"] = { opt = true, cmd = { "Term", "VTerm" } }
 editor["akinsho/toggleterm.nvim"] = {
 	opt = true,
-	event = "BufReadPost",
+	event = "UIEnter",
 	config = conf.toggleterm,
 }
-editor["numtostr/FTerm.nvim"] = { opt = true, event = "BufReadPost" }
 editor["norcalli/nvim-colorizer.lua"] = {
 	opt = true,
 	event = "BufReadPost",


### PR DESCRIPTION
I found `toggleterm.nvim` is functional for all the use cases in this config. So I remove `split-term` and `FTerm.nvim`, leaving `toggleterm.nvim` the only terminal wrapper. Details below:

- Although not being used, I've enhanced `pbind.nvim_load_mapping(mapping)` to allow setting keymap on a specific buffer (`0` represents the current)
- Add global function `_G.toggle_lazygit` to toggle the `lazygit` floating window.
- ~~We are not able to switch to normal mode (with `<C-\><C-n>`) in terminal if we use the default keybinding `<C-\>` to toggle the horizontal terminal. So I change it to `<C-=>`, `=` is next to `\`, easy to get used to~~
- Make the plugin being loaded on "UIEnter" event, in case we want to use the terminal before editing any file.