### PR TITLE
fix(catppuccin): Disable background for ts-rainbow.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -314,6 +314,15 @@ function config.catppuccin()
 				LspDiagnosticsVirtualTextHint = { fg = cp.rosewater },
 				LspDiagnosticsUnderlineHint = { sp = cp.rosewater },
 
+				-- For Ts-Rainbow
+				rainbowcol1 = { bg = cp.none },
+				rainbowcol2 = { bg = cp.none },
+				rainbowcol3 = { bg = cp.none },
+				rainbowcol4 = { bg = cp.none },
+				rainbowcol5 = { bg = cp.none },
+				rainbowcol6 = { bg = cp.none },
+				rainbowcol7 = { bg = cp.none },
+
 				-- For treesitter.
 				TSField = { fg = cp.rosewater },
 				TSProperty = { fg = cp.yellow },


### PR DESCRIPTION
This commit **intentionally** prevents the background for parentheses from covering other texts / background when `transparent_background` is set to `false`.

**Before:**

![Before](https://user-images.githubusercontent.com/50296129/184282588-a9ffef9c-f254-497e-b945-939cfd5af780.png)

**After:**

![After](https://user-images.githubusercontent.com/50296129/184282609-0dab0f80-96e8-4aa1-927f-4fca658b3f4f.png)