### PR TITLE
chore(nvim-tree): Update options from upstream.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -599,6 +599,7 @@ end
 
 function config.nvim_tree()
 	require("nvim-tree").setup({
+		create_in_closed_folder = false,
 		respect_buf_cwd = true,
 		auto_reload_on_write = true,
 		disable_netrw = false,
@@ -612,6 +613,8 @@ function config.nvim_tree()
 		sort_by = "name",
 		update_cwd = true,
 		view = {
+			adaptive_size = false,
+			centralize_selection = false,
 			width = 30,
 			height = 30,
 			side = "left",
@@ -620,43 +623,71 @@ function config.nvim_tree()
 			relativenumber = false,
 			signcolumn = "yes",
 			hide_root_folder = false,
+			float = {
+				enable = false,
+				open_win_config = {
+					relative = "editor",
+					border = "rounded",
+					width = 30,
+					height = 30,
+					row = 1,
+					col = 1,
+				},
+			},
 		},
 		renderer = {
+			add_trailing = false,
+			group_empty = true,
+			highlight_git = false,
+			full_name = false,
+			highlight_opened_files = "none",
+			special_files = { "Cargo.toml", "Makefile", "README.md", "readme.md", "CMakeLists.txt" },
+			symlink_destination = true,
 			indent_markers = {
 				enable = true,
 				icons = {
 					corner = "└ ",
 					edge = "│ ",
+					item = "│ ",
 					none = "  ",
 				},
 			},
 			root_folder_modifier = ":e",
 			icons = {
+				webdev_colors = true,
+				git_placement = "before",
+				show = {
+					file = true,
+					folder = true,
+					folder_arrow = false,
+					git = true,
+				},
 				padding = " ",
 				symlink_arrow = "  ",
 				glyphs = {
-					["default"] = "", --
-					["symlink"] = "",
-					["git"] = {
-						["unstaged"] = "",
-						["staged"] = "", --
-						["unmerged"] = "שׂ",
-						["renamed"] = "", --
-						["untracked"] = "ﲉ",
-						["deleted"] = "",
-						["ignored"] = "", --◌
+					default = "", --
+					symlink = "",
+					bookmark = "",
+					git = {
+						unstaged = "",
+						staged = "", --
+						unmerged = "שׂ",
+						renamed = "", --
+						untracked = "ﲉ",
+						deleted = "",
+						ignored = "", --◌
 					},
-					["folder"] = {
-						-- ['arrow_open'] = "",
-						-- ['arrow_closed'] = "",
-						["arrow_open"] = "",
-						["arrow_closed"] = "",
-						["default"] = "",
-						["open"] = "",
-						["empty"] = "",
-						["empty_open"] = "",
-						["symlink"] = "",
-						["symlink_open"] = "",
+					folder = {
+						-- arrow_open = "",
+						-- arrow_closed = "",
+						arrow_open = "",
+						arrow_closed = "",
+						default = "",
+						open = "",
+						empty = "",
+						empty_open = "",
+						symlink = "",
+						symlink_open = "",
 					},
 				},
 			},
@@ -693,6 +724,52 @@ function config.nvim_tree()
 						buftype = { "nofile", "terminal", "help" },
 					},
 				},
+			},
+			remove_file = {
+				close_window = true,
+			},
+		},
+		diagnostics = {
+			enable = false,
+			show_on_dirs = false,
+			debounce_delay = 50,
+			icons = {
+				hint = "",
+				info = "",
+				warning = "",
+				error = "",
+			},
+		},
+		filesystem_watchers = {
+			enable = true,
+			debounce_delay = 50,
+		},
+		git = {
+			enable = true,
+			ignore = true,
+			show_on_dirs = true,
+			timeout = 400,
+		},
+		trash = {
+			cmd = "gio trash",
+			require_confirm = true,
+		},
+		live_filter = {
+			prefix = "[FILTER]: ",
+			always_show_folders = true,
+		},
+		log = {
+			enable = false,
+			truncate = false,
+			types = {
+				all = false,
+				config = false,
+				copy_paste = false,
+				dev = false,
+				diagnostics = false,
+				git = false,
+				profile = false,
+				watcher = false,
 			},
 		},
 	})


### PR DESCRIPTION
This commit update [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua)'s options from upstream. Some configs are modified from nvim-tree's recent commits to ensure that this configuration still works correctly. _(For example, `folder_arrow = false` is set to ensure proper alignment)_. However, there are no changes to the existing options _(i.e., the appearance does not change)_.

There're also several cleanups, that's, for example, using `default` instead of `["default"]` for consistency _(L668-690)_

> See [:help nvim-tree-setup](https://github.com/kyazdani42/nvim-tree.lua/blob/master/doc/nvim-tree-lua.txt) for changes and options in detail.