### PR TITLE
feat: Use nvim-navic for showing code context.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -4,9 +4,9 @@ vim.cmd([[packadd lsp_signature.nvim]])
 vim.cmd([[packadd lspsaga.nvim]])
 vim.cmd([[packadd cmp-nvim-lsp]])
 vim.cmd([[packadd vim-illuminate]])
+vim.cmd([[packadd nvim-navic]])
 
 local nvim_lsp = require("lspconfig")
-local saga = require("lspsaga")
 local mason = require("mason")
 local mason_lsp = require("mason-lspconfig")
 
@@ -25,7 +25,7 @@ mason_lsp.setup({
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 capabilities = require("cmp_nvim_lsp").update_capabilities(capabilities)
 
-local function custom_attach(client)
+local function custom_attach(client, bufnr)
 	require("lsp_signature").on_attach({
 		bind = true,
 		use_lspsaga = false,
@@ -36,6 +36,7 @@ local function custom_attach(client)
 		handler_opts = { "double" },
 	})
 	require("illuminate").on_attach(client)
+	require("nvim-navic").attach(client, bufnr)
 end
 
 local function switch_source_header_splitcmd(bufnr, splitcmd)

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -435,19 +435,28 @@ end
 
 function config.lualine()
 	local gps = require("nvim-gps")
+	local navic = require("nvim-navic")
 
 	local function escape_status()
 		local ok, m = pcall(require, "better_escape")
 		return ok and m.waiting and "✺ " or ""
 	end
 
-	local function gps_content()
-		if gps.is_available() then
+	local function code_context()
+		if navic.is_available() and navic.get_location() ~= "" then
+			return navic.get_location()
+		elseif gps.is_available() then
 			return gps.get_location()
 		else
 			return ""
 		end
 	end
+
+	local conditions = {
+		check_code_context = function()
+			return gps.is_available() or navic.is_available()
+		end,
+	}
 
 	local mini_sections = {
 		lualine_a = {},
@@ -526,7 +535,7 @@ function config.lualine()
 			lualine_a = { "mode" },
 			lualine_b = { { "branch" }, { "diff" } },
 			lualine_c = {
-				{ gps_content, cond = gps.is_available },
+				{ code_context, cond = conditions.check_code_context },
 			},
 			lualine_x = {
 				{ escape_status },
@@ -594,6 +603,45 @@ function config.nvim_gps()
 			["rust"] = true,
 		},
 		separator = " > ",
+	})
+end
+
+function config.nvim_navic()
+	vim.g.navic_silence = true
+
+	require("nvim-navic").setup({
+		icons = {
+			Method = " ",
+			Function = " ",
+			Constructor = " ",
+			Field = " ",
+			Variable = " ",
+			Class = "ﴯ ",
+			Interface = " ",
+			Module = " ",
+			Property = "ﰠ ",
+			Enum = " ",
+			File = " ",
+			EnumMember = " ",
+			Constant = " ",
+			Struct = " ",
+			Event = " ",
+			Operator = " ",
+			TypeParameter = " ",
+			Namespace = " ",
+			Object = " ",
+			Array = "[] ",
+			Boolean = " ",
+			Number = " ",
+			Null = "ﳠ ",
+			Key = " ",
+			String = " ",
+			Package = " ",
+		},
+		highlight = false,
+		separator = " > ",
+		depth_limit = 0,
+		depth_limit_indicator = "..",
 	})
 end
 

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -259,7 +259,7 @@ function config.catppuccin()
 			neotree = { enabled = false, show_root = true, transparent_panel = false },
 			telekasten = false,
 			mini = false,
-			aerial = true,
+			aerial = false,
 			vimwiki = true,
 			beacon = false,
 			navic = true,

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -630,7 +630,7 @@ function config.nvim_navic()
 			TypeParameter = " ",
 			Namespace = " ",
 			Object = " ",
-			Array = "[] ",
+			Array = " ",
 			Boolean = " ",
 			Number = " ",
 			Null = "ﳠ ",

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -262,7 +262,7 @@ function config.catppuccin()
 			aerial = true,
 			vimwiki = true,
 			beacon = false,
-			navic = false,
+			navic = true,
 			overseer = false,
 		},
 		color_overrides = {
@@ -638,7 +638,7 @@ function config.nvim_navic()
 			String = " ",
 			Package = " ",
 		},
-		highlight = false,
+		highlight = true,
 		separator = " > ",
 		depth_limit = 0,
 		depth_limit_indicator = "..",

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -15,13 +15,18 @@ ui["rcarriga/nvim-notify"] = {
 }
 ui["hoob3rt/lualine.nvim"] = {
 	opt = true,
-	after = "nvim-gps",
+	after = { "nvim-gps", "nvim-navic" },
 	config = conf.lualine,
 }
 ui["SmiteshP/nvim-gps"] = {
 	opt = true,
 	after = "nvim-treesitter",
 	config = conf.nvim_gps,
+}
+ui["SmiteshP/nvim-navic"] = {
+	opt = true,
+	after = "nvim-lspconfig",
+	config = conf.nvim_navic,
 }
 ui["goolord/alpha-nvim"] = {
 	opt = true,


### PR DESCRIPTION
As mentioned in #188. This PR would also close #188 once merged.

- Note that we replace `nvim-gps` with `nvim-navic` in _most_ cases, but gps is still preserved for Treesitter fallback _(i.e., for filetypes / servers that are unsupported by nvim-navic)_
- Catppuccin's integration with navic is also enabled for nice-looking highlights.
- The icons for navic came from nvim-cmp.

**Minor Change**
- Disabled highlight settings for aerial of catppuccin 