### PR TITLE
chore(lspsaga): Enable diagnostic symbols for sidebar.

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -5,6 +5,18 @@ function config.nvim_lsp()
 end
 
 function config.lspsaga()
+	-- Set icons for sidebar.
+	local diagnostic_icons = {
+		Error = " ",
+		Warn = " ",
+		Info = " ",
+		Hint = " ",
+	}
+	for type, icon in pairs(diagnostic_icons) do
+		local hl = "DiagnosticSign" .. type
+		vim.fn.sign_define(hl, { text = icon, texthl = hl })
+	end
+
 	local saga = require("lspsaga")
 	saga.init_lsp_saga()
 end


### PR DESCRIPTION
**TL;DR The icon set for lsp diagnostic symbols on sidebar is now being controlled by nvim-upstream directly.**

> For detailed explanation, visit https://github.com/glepnir/lspsaga.nvim/issues/428.