### PR TITLE
fix(clangd[lsp]): Args aren't being passed correctly.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -106,12 +106,18 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 			capabilities = copy_capabilities,
 			single_file_support = true,
 			on_attach = custom_attach,
-			args = {
+			cmd = {
+				"clangd",
 				"--background-index",
-				"-std=c++20",
 				"--pch-storage=memory",
+				-- You MUST set this arg ↓ to your clangd executable location (if not included)!
+				"--query-driver=/usr/bin/clang++,/usr/bin/**/clang-*,/bin/clang,/bin/clang++,/usr/bin/gcc,/usr/bin/g++",
 				"--clang-tidy",
-				"--suggest-missing-includes",
+				"--all-scopes-completion",
+				"--cross-file-rename",
+				"--completion-style=detailed",
+				"--header-insertion-decorators",
+				"--header-insertion=iwyu",
 			},
 			commands = {
 				ClangdSwitchSourceHeader = {


### PR DESCRIPTION
There've been updates to `clangd (llvm, 13 - 14)` that modified the method to pass args to the lsp.

**TL;DR: We need to use the `cmd` table to pass clangd's arguments and set command-line arguments of the compiler (e.g., `clang++`) via clangd's configuration file in the source tree or an OS-specific directory. For most cases, `--query-driver` MUST be set so that clangd can correctly parse system's includes (e.g., for using `#include<type_traits>`), especially when the user doesn't provide `compile_commands.json` or `compile_flags.txt`.**
*****
### Detailed Discussion about Configuration File _(Maybe we need to add this to the wiki?)_
Configuration is stored in YAML files. These are either:
- **project configuration**: a file named `.clangd` in the source tree. _(clangd searches in all parent directories of the active file)_.
  - Generally this should be used for shared and checked-in settings.
  - _(Existing directories named `.clangd` can be deleted. These were used for temporary storage by clangd before version 11.)_
- **user configuration:** a `config.yaml` file in an OS-specific directory:
  - Windows: `%LocalAppData%\clangd\config.yaml`, typically `C:\Users\Bob\AppData\Local\clangd\config.yaml`.
  - macOS: `~/Library/Preferences/clangd/config.yaml`.
  - Linux and others: `$XDG_CONFIG_HOME/clangd/config.yaml`, typically `~/.config/clangd/config.yaml`.

<details>
    <summary>Example <i>(My)</i> Configuration</summary>
<p>

```yaml
CompileFlags:
  Add: [-Wall, -Wextra, -pedantic, -std=c++17]
  Remove: # Nothing.
  Compiler: clang++
Diagnostics:
  ClangTidy:
    Add: ["*"]
    Remove:
      [
        altera-*,
        bugprone-easily-swappable-parameters,
        cppcoreguidelines-avoid-c-arrays,
        cppcoreguidelines-avoid-non-const-global-variables,
        cppcoreguidelines-owning-memory,
        cppcoreguidelines-pro-bounds-constant-array-index,
        cppcoreguidelines-pro-bounds-pointer-arithmetic,
        cppcoreguidelines-pro-bounds-array-to-pointer-decay,
        cppcoreguidelines-pro-type-reinterpret-cast,
        cppcoreguidelines-pro-type-vararg,
        fuchsia-default-arguments-calls,
        fuchsia-default-arguments-declarations,
        fuchsia-overloaded-operator,
        fuchsia-statically-constructed-objects,
        google-build-using-namespace,
        google-objc-function-naming,
        google-readability-braces-around-statements,
        google-readability-casting,
        hicpp-avoid-c-arrays,
        hicpp-braces-around-statements,
        hicpp-no-array-decay,
        hicpp-signed-bitwise,
        hicpp-vararg,
        llvm-else-after-return,
        llvmlibc-callee-namespace,
        llvmlibc-implementation-in-namespace,
        llvmlibc-restrict-system-libc-headers,
        misc-no-recursion,
        modernize-avoid-c-arrays,
        modernize-use-nodiscard,
        modernize-use-trailing-return-type,
        readability-braces-around-statements,
        readability-else-after-return,
        readability-magic-numbers,
        readability-redundant-access-specifiers,
      ]
    CheckOptions:
      readability-identifier-naming.VariableCase: [CamelCase]
InlayHints:
  Enabled: No
  ParameterNames: Yes
  DeducedTypes: Yes
Hover:
  ShowAKA: Yes
Index:
  Background: Build
```

<br />
</details>

For more details visit: [nvim-lspconfig's server setup document](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#clangd) and [LLVM clangd's website](https://clangd.llvm.org/).