### PR TITLE
chore(efm): Deprecate clang-tidy linter due to usage of clangd.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -228,7 +228,6 @@ efmls.init({
 -- Require `efmls-configs-nvim`'s config here
 
 local vint = require("efmls-configs.linters.vint")
-local clangtidy = require("efmls-configs.linters.clang_tidy")
 local eslint = require("efmls-configs.linters.eslint")
 local flake8 = require("efmls-configs.linters.flake8")
 local shellcheck = require("efmls-configs.linters.shellcheck")
@@ -261,8 +260,8 @@ flake8 = vim.tbl_extend("force", flake8, {
 efmls.setup({
 	vim = { formatter = vint },
 	lua = { formatter = luafmt },
-	c = { formatter = clangfmt, linter = clangtidy },
-	cpp = { formatter = clangfmt, linter = clangtidy },
+	c = { formatter = clangfmt },
+	cpp = { formatter = clangfmt },
 	python = { formatter = black },
 	vue = { formatter = prettier },
 	typescript = { formatter = prettier, linter = eslint },


### PR DESCRIPTION
See #193. Clangd comes with `--clang-tidy` support, so there's no need to spawn clang-tidy using efm again.