### PR TITLE
fix(ts-rainbow): Lazy-load event.

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -23,7 +23,6 @@ editor["nvim-treesitter/nvim-treesitter-textobjects"] = {
 editor["p00f/nvim-ts-rainbow"] = {
 	opt = true,
 	after = "nvim-treesitter",
-	event = "BufReadPost",
 }
 editor["JoosepAlviste/nvim-ts-context-commentstring"] = {
 	opt = true,


### PR DESCRIPTION
Currently `ts-rainbow` would be loaded **after** treesitter during startup **AND** during the event: `BufReadPost`, which could lead to highlight problems _(e.g., the highlights set by catppuccin will have no effect)_.