### PR TITLE
chore(vim-illuminate): Migrate to V2.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -3,7 +3,6 @@ local formatting = require("modules.completion.formatting")
 vim.cmd([[packadd lsp_signature.nvim]])
 vim.cmd([[packadd lspsaga.nvim]])
 vim.cmd([[packadd cmp-nvim-lsp]])
-vim.cmd([[packadd vim-illuminate]])
 vim.cmd([[packadd nvim-navic]])
 
 local nvim_lsp = require("lspconfig")
@@ -35,7 +34,6 @@ local function custom_attach(client, bufnr)
 		hi_parameter = "Search",
 		handler_opts = { "double" },
 	})
-	require("illuminate").on_attach(client)
 	require("nvim-navic").attach(client, bufnr)
 end
 

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -73,18 +73,36 @@ function config.nvim_treesitter()
 end
 
 function config.illuminate()
-	vim.g.Illuminate_highlightUnderCursor = 0
-	vim.g.Illuminate_ftblacklist = {
-		"help",
-		"dashboard",
-		"alpha",
-		"packer",
-		"norg",
-		"DoomInfo",
-		"NvimTree",
-		"Outline",
-		"toggleterm",
-	}
+	-- Use background for "Visual" as highlight for words. Change this behavior here!
+	if vim.api.nvim_get_hl_by_name("Visual", true).background then
+		local illuminate_bg = string.format("#%06x", vim.api.nvim_get_hl_by_name("Visual", true).background)
+
+		vim.api.nvim_set_hl(0, "IlluminatedWordText", { bg = illuminate_bg })
+		vim.api.nvim_set_hl(0, "IlluminatedWordRead", { bg = illuminate_bg })
+		vim.api.nvim_set_hl(0, "IlluminatedWordWrite", { bg = illuminate_bg })
+	end
+
+	require("illuminate").configure({
+		providers = {
+			"lsp",
+			"treesitter",
+			"regex",
+		},
+		delay = 100,
+		filetypes_denylist = {
+			"alpha",
+			"dashboard",
+			"DoomInfo",
+			"fugitive",
+			"help",
+			"norg",
+			"NvimTree",
+			"Outline",
+			"packer",
+			"toggleterm",
+		},
+		under_cursor = false,
+	})
 end
 
 function config.nvim_comment()

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -3,6 +3,7 @@ local conf = require("modules.editor.config")
 
 editor["junegunn/vim-easy-align"] = { opt = true, cmd = "EasyAlign" }
 editor["RRethy/vim-illuminate"] = {
+	opt = true,
 	event = "BufReadPost",
 	config = conf.illuminate,
 }


### PR DESCRIPTION
[vim-illuminate](https://github.com/RRethy/vim-illuminate) was updated a few hours ago. This commit migrates all configs to `V2 (nvim)` version. See illuminate's repo for details.

**Note that:** The default appearance for _illumination_ is now underlined (`hi def IlluminatedWordText gui=underline` from source code), and I use:
```lua
local illuminate_bg = string.format("#%06x", vim.api.nvim_get_hl_by_name("Visual", true).background)
```
to restore the original way of display using the `Visual` highlight. This was the default in `V1` and `string.format("#%06x", ...)` is being used because the numbers returned by nvim api are color codes in **decimal**. We can convert them to 6 digit hexadecimal with formatting specifier: `%06x`.