### PR TITLE
fix: CursorHold integration with lspsaga.

### DIFF
--- a/lua/modules/completion/plugins.lua
+++ b/lua/modules/completion/plugins.lua
@@ -21,6 +21,7 @@ completion["williamboman/mason.nvim"] = {
 completion["glepnir/lspsaga.nvim"] = {
 	opt = true,
 	after = "nvim-lspconfig",
+	requires = { { "antoinemadec/FixCursorHold.nvim", opt = true } },
 	config = conf.lspsaga,
 }
 completion["ray-x/lsp_signature.nvim"] = { opt = true, after = "nvim-lspconfig" }


### PR DESCRIPTION
[antoinemadec/FixCursorHold.nvim](https://github.com/antoinemadec/FixCursorHold.nvim) is **STRONGLY RECOMMENDED** by almost every plugin that uses the events: `CursorHold` or `CursorHoldI` due to a performance bug _(these events are blocked by timer_start())_, which means some behaviors would have no effect without this fix. See issue #12587 of neovim upstream for details.