### PR TITLE
fix: add and change luasnips option <delete_check_events>

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -204,6 +204,7 @@ function config.luasnip()
 	require("luasnip").config.set_config({
 		history = true,
 		updateevents = "TextChanged,TextChangedI",
+		delete_check_events = "TextChanged,InsertLeave",
 	})
 	require("luasnip.loaders.from_lua").lazy_load()
 	require("luasnip.loaders.from_vscode").lazy_load()


### PR DESCRIPTION
Luasnips snippets dynamic node can be triggered after undo operation
Related to https://github.com/L3MON4D3/LuaSnip/issues/238.
Maybe this issue can be reproduced by contributors.