### PR TITLE
chore(lspsaga): Update diagnostics icons for consistency.

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -9,8 +9,8 @@ function config.lspsaga()
 	local diagnostic_icons = {
 		Error = " ",
 		Warn = " ",
-		Info = " ",
-		Hint = " ",
+		Info = " ",
+		Hint = " ",
 	}
 	for type, icon in pairs(diagnostic_icons) do
 		local hl = "DiagnosticSign" .. type
@@ -35,7 +35,9 @@ function config.lspsaga()
 	kind[26][2] = " "
 
 	local saga = require("lspsaga")
-	saga.init_lsp_saga()
+	saga.init_lsp_saga({
+		diagnostic_header = { " ", " ", "  ", " " },
+	})
 end
 
 function config.cmp()


### PR DESCRIPTION
This commit update lspsaga's lsp diagnostics icons so that it stays consistent with other plugins.

- **Source:**

https://github.com/ayamir/nvimdots/blob/859206f4bd6b14bde47f17e806eb244ea4370aaf/lua/modules/ui/config.lua#L528

https://github.com/ayamir/nvimdots/blob/859206f4bd6b14bde47f17e806eb244ea4370aaf/lua/modules/ui/config.lua#L768-L769

https://github.com/ayamir/nvimdots/blob/859206f4bd6b14bde47f17e806eb244ea4370aaf/lua/modules/tools/config.lua#L116-L117