### PR TITLE
style(bufferline): Cleanup.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -831,7 +831,7 @@ function config.nvim_bufferline()
 					padding = 1,
 				},
 			},
-			diagnostics_indicator = function(count, level, diagnostics_dict, context)
+			diagnostics_indicator = function(count)
 				return "(" .. count .. ")"
 			end,
 		},


### PR DESCRIPTION
This commit removed unnecessary parameters from bufferline's `disgnostics_indicator` function so as to suppress warnings.