### PR TITLE
Fix(lualine): Git diffs aren't rendered in some cases.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -441,6 +441,17 @@ function config.lualine()
 		return ok and m.waiting and "✺ " or ""
 	end
 
+	local function diff_source()
+		local gitsigns = vim.b.gitsigns_status_dict
+		if gitsigns then
+			return {
+				added = gitsigns.added,
+				modified = gitsigns.changed,
+				removed = gitsigns.removed,
+			}
+		end
+	end
+
 	local mini_sections = {
 		lualine_a = {},
 		lualine_b = {},
@@ -516,7 +527,7 @@ function config.lualine()
 		},
 		sections = {
 			lualine_a = { "mode" },
-			lualine_b = { { "branch" }, { "diff" } },
+			lualine_b = { { "branch" }, { "diff", source = diff_source } },
 			lualine_c = {
 				{ navic.get_location, cond = navic.is_available },
 			},


### PR DESCRIPTION
This is a known bug of `lualine` _(Bug: Git diagnostic diff (+ ~ -) disappears after vim.diagnostic.* is called)_, current work-around is to use `gitsigns` as source for git diff.