### PR TITLE
fix(notify): Set minimum log level support.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -420,6 +420,8 @@ function config.notify()
 		background_colour = "Normal",
 		---@usage minimum width for notification windows
 		minimum_width = 50,
+		---@usage notifications with level lower than this would be ignored. [ERROR > WARN > INFO > DEBUG > TRACE]
+		level = "TRACE",
 		---@usage Icons for the different levels
 		icons = {
 			ERROR = "",


### PR DESCRIPTION
Minimum log level is set for nvim-notify so that some notifications won't be ignored and made it user-customizable. 