### PR TITLE
refactor(messages): Update notification messages.

### DIFF
--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -101,7 +101,7 @@ function plugins.back_compile()
 		os.rename(packer_compiled, bak_compiled)
 	end
 	plugins.compile()
-	vim.notify("Packer Compiled!", vim.log.levels.INFO)
+	vim.notify("Packer Compile Success!", vim.log.levels.INFO, { title = "Success!" })
 end
 
 function plugins.auto_compile()

--- a/lua/modules/completion/formatting.lua
+++ b/lua/modules/completion/formatting.lua
@@ -20,13 +20,26 @@ vim.api.nvim_create_user_command("FormatToggle", function()
 end, {})
 
 local block_list = {}
-vim.api.nvim_create_user_command("SelectedFormatToggle", function(opts)
+vim.api.nvim_create_user_command("FormatterToggle", function(opts)
 	if block_list[opts.args] == nil then
-		print("Select disable format file type is " .. opts.args)
+		vim.notify(
+			string.format("[LSP]Formatter for [%s] has been recorded in list and disabled.", opts.args),
+			vim.log.levels.WARN,
+			{ title = "LSP Formatter Warning!" }
+		)
 		block_list[opts.args] = true
-		return
+	else
+		block_list[opts.args] = not block_list[opts.args]
+		vim.notify(
+			string.format(
+				"[LSP]Formatter for [%s] has been %s.",
+				opts.args,
+				not block_list[opts.args] and "enabled" or "disabled"
+			),
+			not block_list[opts.args] and vim.log.levels.INFO or vim.log.levels.WARN,
+			{ title = string.format("LSP Formatter %s", not block_list[opts.args] and "Info" or "Warning") }
+		)
 	end
-	block_list[opts.args] = not block_list[opts.args]
 end, {
 	nargs = 1,
 	complete = function(_, _, _)
@@ -61,13 +74,17 @@ function M.enable_format_on_save(is_configured)
 		end,
 	})
 	if not is_configured then
-		vim.notify("Enabled format-on-save", vim.log.levels.INFO)
+		vim.notify(
+			"Successfully enabled format-on-save",
+			vim.log.levels.INFO,
+			{ title = "Settings modification success!" }
+		)
 	end
 end
 
 function M.disable_format_on_save()
 	pcall(vim.api.nvim_del_augroup_by_name, "format_on_save")
-	vim.notify("Disabled format-on-save", vim.log.levels.INFO)
+	vim.notify("Disabled format-on-save", vim.log.levels.INFO, { title = "Settings modification success!" })
 end
 
 function M.configure_format_on_save()
@@ -131,22 +148,42 @@ function M.format(opts)
 	end, clients)
 
 	if #clients == 0 then
-		vim.notify("[LSP] Format request failed, no matching language servers.")
+		vim.notify(
+			"[LSP] Format request failed, no matching language servers.",
+			vim.log.levels.WARN,
+			{ title = "Formatting Failed!" }
+		)
 	end
 
 	local timeout_ms = opts.timeout_ms
 	for _, client in pairs(clients) do
 		if block_list[vim.bo.filetype] == true then
-			vim.notify(string.format("[LSP][%s] format [%s] has disable", client.name, vim.bo.filetype))
+			vim.notify(
+				string.format(
+					"[LSP][%s] formatter for [%s] has been disabled. This file was not processed.",
+					client.name,
+					vim.bo.filetype
+				),
+				vim.log.levels.WARN,
+				{ title = "LSP Formatter Warning!" }
+			)
 			return
 		end
 		local params = vim.lsp.util.make_formatting_params(opts.formatting_options)
 		local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, bufnr)
 		if result and result.result then
 			vim.lsp.util.apply_text_edits(result.result, bufnr, client.offset_encoding)
-			vim.notify(string.format("Format successfully with %s!", client.name), vim.log.levels.INFO)
+			vim.notify(
+				string.format("Format successfully with %s!", client.name),
+				vim.log.levels.INFO,
+				{ title = "LSP Format Success!" }
+			)
 		elseif err then
-			vim.notify(string.format("[LSP][%s] %s", client.name, err), vim.log.levels.WARN)
+			vim.notify(
+				string.format("[LSP][%s] %s", client.name, err),
+				vim.log.levels.ERROR,
+				{ title = "LSP Format Error!" }
+			)
 		end
 	end
 end


### PR DESCRIPTION
This commit refactored most of the messages thrown by `notify`, with a _more_ human-readable style and title support. Some log levels are changed for cognitive understanding consistency.

There's also a functional change in `lua/modules/completion/formatting.lua`, here's the summary:
- The `SelectedFormatToggle` command was changed to `FormatterToggle` for consistency and better-understanding.
- The processing logic was changed -- the `if` statement shouldn't terminate that early with `return` - otherwise there could be cognitive problems.
- Use notify instead for message prompt.

<details>
    <summary>Diff <i>(for the <code class="notranslate">FormatterToggle</code> section)</i></summary>
<p>

```diff
diff --git a/lua/modules/completion/formatting.lua b/lua/modules/completion/formatting.lua
index 34c5c28..bb1080c 100644
--- a/lua/modules/completion/formatting.lua
+++ b/lua/modules/completion/formatting.lua
@@ -20,13 +20,26 @@ vim.api.nvim_create_user_command("FormatToggle", function()
 end, {})
 
 local block_list = {}
-vim.api.nvim_create_user_command("SelectedFormatToggle", function(opts)
+vim.api.nvim_create_user_command("FormatterToggle", function(opts)
 	if block_list[opts.args] == nil then
-		print("Select disable format file type is " .. opts.args)
+		vim.notify(
+			string.format("[LSP]Formatter for [%s] has been recorded in list and disabled.", opts.args),
+			vim.log.levels.WARN,
+			{ title = "LSP Formatter Warning!" }
+		)
 		block_list[opts.args] = true
-		return
+	else
+		block_list[opts.args] = not block_list[opts.args]
+		vim.notify(
+			string.format(
+				"[LSP]Formatter for [%s] has been %s.",
+				opts.args,
+				not block_list[opts.args] and "enabled" or "disabled"
+			),
+			not block_list[opts.args] and vim.log.levels.INFO or vim.log.levels.WARN,
+			{ title = string.format("LSP Formatter %s", not block_list[opts.args] and "Info" or "Warning") }
+		)
 	end
-	block_list[opts.args] = not block_list[opts.args]
 end, {
 	nargs = 1,
 	complete = function(_, _, _)

@@ -131,22 +148,42 @@ function M.format(opts)
 	local timeout_ms = opts.timeout_ms
 	for _, client in pairs(clients) do
 		if block_list[vim.bo.filetype] == true then
-			vim.notify(string.format("[LSP][%s] format [%s] has disable", client.name, vim.bo.filetype))
+			vim.notify(
+				string.format(
+					"[LSP][%s] formatter for [%s] has been disabled. This file was not processed.",
+					client.name,
+					vim.bo.filetype
+				),
+				vim.log.levels.WARN,
+				{ title = "LSP Formatter Warning!" }
+			)
 			return
 		end
```

<br />
</details>