### PR TITLE
fix(catppuccin): Integration with navic.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -266,7 +266,7 @@ function config.catppuccin()
 			aerial = false,
 			vimwiki = true,
 			beacon = false,
-			navic = true,
+			navic = { enabled = true, custom_bg = "NONE" },
 			overseer = false,
 		},
 		color_overrides = {


### PR DESCRIPTION
If `custom_bg` was not set then we could get a strange-looking white background or no highlight. 