### PR TITLE
feat(catppuccin & bufferline)!: Move configs in place.

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -859,7 +859,7 @@ function config.nvim_bufferline()
 			highlights = require("catppuccin.groups.integrations.bufferline").get({
 				styles = { "italic", "bold" },
 				custom = {
-					all = {
+					mocha = {
 						-- Warnings
 						warning = { fg = cp.yellow },
 						warning_visible = { fg = cp.yellow },

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -245,11 +245,6 @@ function config.catppuccin()
 			vim_sneak = false,
 			fern = false,
 			barbar = false,
-			bufferline = {
-				enabled = true,
-				italics = true,
-				bolds = true,
-			},
 			markdown = true,
 			lightspeed = false,
 			ts_rainbow = true,
@@ -327,28 +322,6 @@ function config.catppuccin()
 				rainbowcol5 = { bg = cp.none },
 				rainbowcol6 = { bg = cp.none },
 				rainbowcol7 = { bg = cp.none },
-
-				-- For bufferline
-				BufferLineWarning = { fg = cp.yellow },
-				BufferLineWarningVisible = { fg = cp.yellow },
-				BufferLineWarningDiagnostic = { fg = cp.yellow },
-				BufferLineWarningDiagnosticVisible = { fg = cp.yellow },
-				BufferLineWarningSelected = { fg = cp.yellow },
-				BufferLineWarningDiagnosticSelected = { fg = cp.yellow },
-
-				BufferLineInfo = { fg = cp.sky },
-				BufferLineInfoVisible = { fg = cp.sky },
-				BufferLineInfoDiagnostic = { fg = cp.sky },
-				BufferLineInfoDiagnosticVisible = { fg = cp.sky },
-				BufferLineInfoDiagnosticSelected = { fg = cp.sky },
-				BufferLineInfoSelected = { fg = cp.sky },
-
-				BufferLineHint = { fg = cp.rosewater },
-				BufferLineHintVisible = { fg = cp.rosewater },
-				BufferLineHintDiagnostic = { fg = cp.rosewater },
-				BufferLineHintDiagnosticVisible = { fg = cp.rosewater },
-				BufferLineHintSelected = { fg = cp.rosewater },
-				BufferLineHintDiagnosticSelected = { fg = cp.rosewater },
 
 				-- For treesitter.
 				TSField = { fg = cp.rosewater },
@@ -845,9 +818,9 @@ function config.nvim_tree()
 end
 
 function config.nvim_bufferline()
-	require("bufferline").setup({
+	local opts = {
 		options = {
-			number = "none",
+			number = nil,
 			modified_icon = "✥",
 			buffer_close_icon = "",
 			left_trunc_marker = "",
@@ -873,7 +846,50 @@ function config.nvim_bufferline()
 				return "(" .. count .. ")"
 			end,
 		},
-	})
+		-- Change bufferline's highlights here! See `:h bufferline-highlights` for detailed explanation.
+		-- Note: If you use catppuccin then modify the colors below!
+		highlights = {},
+	}
+
+	if vim.g.colors_name == "catppuccin" then
+		local cp = require("catppuccin.palettes").get_palette() -- Get the palette.
+		cp.none = "NONE" -- Special setting for complete transparent fg/bg.
+
+		local catppuccin_hl_overwrite = {
+			highlights = require("catppuccin.groups.integrations.bufferline").get({
+				styles = { "italic", "bold" },
+				custom = {
+					all = {
+						-- Warnings
+						warning = { fg = cp.yellow },
+						warning_visible = { fg = cp.yellow },
+						warning_selected = { fg = cp.yellow },
+						warning_diagnostic = { fg = cp.yellow },
+						warning_diagnostic_visible = { fg = cp.yellow },
+						warning_diagnostic_selected = { fg = cp.yellow },
+						-- Infos
+						info = { fg = cp.sky },
+						info_visible = { fg = cp.sky },
+						info_selected = { fg = cp.sky },
+						info_diagnostic = { fg = cp.sky },
+						info_diagnostic_visible = { fg = cp.sky },
+						info_diagnostic_selected = { fg = cp.sky },
+						-- Hint
+						hint = { fg = cp.rosewater },
+						hint_visible = { fg = cp.rosewater },
+						hint_selected = { fg = cp.rosewater },
+						hint_diagnostic = { fg = cp.rosewater },
+						hint_diagnostic_visible = { fg = cp.rosewater },
+						hint_diagnostic_selected = { fg = cp.rosewater },
+					},
+				},
+			}),
+		}
+
+		opts = vim.tbl_deep_extend("force", opts, catppuccin_hl_overwrite)
+	end
+
+	require("bufferline").setup(opts)
 end
 
 function config.gitsigns()


### PR DESCRIPTION
Ref: https://github.com/ayamir/nvimdots/pull/212#issuecomment-1229195013. As usual, we still retain maximum compatibility with other colorschemes. Catppuccin's special configs are overwritten by:
```lua
opts = vim.tbl_deep_extend("force", opts, catppuccin_hl_overwrite)
```

**We might need to update the wiki for this change. I'll document this asap.**