### PR TITLE
chore(telescope): Added even more ignore patterns.

### DIFF
--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -31,7 +31,7 @@ function config.telescope()
 			borderchars = { " ", " ", " ", " ", " ", " ", " ", " " },
 			layout_strategy = "horizontal",
 			path_display = { "absolute" },
-			file_ignore_patterns = { ".git" },
+			file_ignore_patterns = { ".git/", ".cache", "%.class", "%.pdf", "%.mkv", "%.mp4", "%.zip" },
 			layout_config = {
 				prompt_position = "bottom",
 				horizontal = {


### PR DESCRIPTION
> Ref: https://github.com/ayamir/nvimdots/commit/281a60b180d39fe89536d94a347a38dd1d1914d5, https://github.com/ayamir/nvimdots/issues/218

I've added even more file ignore patterns for telescope. Those pre/suffixes are common file extensions or folders that either couldn't be edited in neovim _(e.g., `%.pdf`)_ or shouldn't be included in the list _(e.g., `.cache`)_.