### PR TITLE
chore: Remove commit restriction for ts-textobjects

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -20,7 +20,6 @@ editor["nvim-treesitter/nvim-treesitter"] = {
 editor["nvim-treesitter/nvim-treesitter-textobjects"] = {
 	opt = true,
 	after = "nvim-treesitter",
-	commit = "761e283a8e3ab80ee5ec8daf4f19d92d23ee37e4",
 }
 editor["p00f/nvim-ts-rainbow"] = {
 	opt = true,


### PR DESCRIPTION
> This reverts commit a8aa909baeb844848d4d30050d1884d38611ef2b, reversing changes made to 3b9d470b41414089f2b3022232dd1a8d69ec1089.

Ref: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/commit/be98836bf0de595c3d8dd6d5e4b2f5d68483631d. The visual mapping problem has been resolved.