### PR TITLE
chore(efm[lsp]): Load options using modules.

### DIFF
--- a/lua/modules/completion/efm/formatters/clangfmt.lua
+++ b/lua/modules/completion/efm/formatters/clangfmt.lua
@@ -1,0 +1,1 @@
+return { formatCommand = "clang-format -style='{BasedOnStyle: LLVM, IndentWidth: 4}'", formatStdin = true }

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -242,16 +242,13 @@ local shellcheck = require("efmls-configs.linters.shellcheck")
 
 local black = require("efmls-configs.formatters.black")
 local luafmt = require("efmls-configs.formatters.stylua")
-local clangfmt = {
-	formatCommand = "clang-format -style='{BasedOnStyle: LLVM, IndentWidth: 4}'",
-	formatStdin = true,
-}
 local prettier = require("efmls-configs.formatters.prettier")
 local shfmt = require("efmls-configs.formatters.shfmt")
 
 -- Add your own config for formatter and linter here
 
 -- local rustfmt = require("modules.completion.efm.formatters.rustfmt")
+local clangfmt = require("modules.completion.efm.formatters.clangfmt")
 
 -- Override default config here
 


### PR DESCRIPTION
This is a better _(and possibly clearer and easier to maintain)_ option for importing user-specific configs for efm, and might be the original design pattern as well.