### PR TITLE
feat(workflow & stylua): Enable CI (code style check)

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,0 +1,12 @@
+name: stylua
+on: [push, pull_request]
+
+jobs:
+  stylua:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JohnnyMorganz/stylua-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check --config-path=stylua.toml .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -1,4 +1,4 @@
-name: stylua
+name: style check
 on: [push, pull_request]
 
 jobs:

--- a/lua/modules/completion/efm/formatters/rustfmt.lua
+++ b/lua/modules/completion/efm/formatters/rustfmt.lua
@@ -1,1 +1,1 @@
-return {formatCommand = "rustfmt", formatStdin = true}
+return { formatCommand = "rustfmt", formatStdin = true }

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Tabs"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"


### PR DESCRIPTION
It would be a great idea to enable **CI** _(in this case, code style check)_ for PRs and pushes to ensure consistency in coding styles. All files have been formatted using stylua again for successful workflow run.

**IMPORTANT NOTE:**
- Go to `Settings -> Branches -> Branch protection rules -> Edit Rule` _(possibly called main)_ and tick **require status checks to pass before merging**, choose this new action and we're all set lol.

Current status:

[![style check](https://github.com/Jint-lzxy/nvimdots/actions/workflows/style_check.yml/badge.svg?branch=ci)](https://github.com/Jint-lzxy/nvimdots/actions/workflows/style_check.yml) <--- For those coming afterwards, this badge would be invalid after a successful merging and branch cleaning.