### PR TITLE
chore(luasnip & cmp): Fix broken keymaps.

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -84,6 +84,7 @@ function config.cmp()
 	local t = function(str)
 		return vim.api.nvim_replace_termcodes(str, true, true, true)
 	end
+
 	local has_words_before = function()
 		local line, col = unpack(vim.api.nvim_win_get_cursor(0))
 		return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
@@ -195,6 +196,8 @@ function config.cmp()
 			["<Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_next_item()
+				elseif require("luasnip").expand_or_jumpable() then
+					vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"), "")
 				elseif has_words_before() then
 					cmp.complete()
 				else
@@ -204,24 +207,12 @@ function config.cmp()
 			["<S-Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_prev_item()
-				else
-					fallback()
-				end
-			end, { "i", "s" }),
-			["<C-h>"] = function(fallback)
-				if require("luasnip").jumpable(-1) then
+				elseif require("luasnip").jumpable(-1) then
 					vim.fn.feedkeys(t("<Plug>luasnip-jump-prev"), "")
 				else
 					fallback()
 				end
-			end,
-			["<C-l>"] = function(fallback)
-				if require("luasnip").expand_or_jumpable() then
-					vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"), "")
-				else
-					fallback()
-				end
-			end,
+			end, { "i", "s" }),
 		}),
 		snippet = {
 			expand = function(args)


### PR DESCRIPTION
Currently, the `<C-h>` and `<C-l>` mappings used to navigate between snippet sections could conflict with other mappings in the most hidden area _(for example, in extreme cases, typing `<C-h>` may cause the character after the cursor to be deleted_ [a.k.a., invoking `<BS>`]_)_. This commit modified this behavior and enabled what's called _super-tab-like mapping_, which uses `<Tab>` and `<S-Tab>` to handle all navigation requests. See the code for implementation details.