### PR TITLE
chore: Allow generic `<leader>` keybinding for lazy-load.

### DIFF
--- a/lua/modules/tools/plugins.lua
+++ b/lua/modules/tools/plugins.lua
@@ -34,7 +34,7 @@ tools["michaelb/sniprun"] = {
 }
 tools["folke/which-key.nvim"] = {
 	opt = true,
-	keys = ",",
+	keys = "<leader>",
 	config = conf.which_key,
 }
 tools["folke/trouble.nvim"] = {


### PR DESCRIPTION
After this commit, no matter which key the user sets as `<leader>`, which-key.nvim will always be loaded when appropriate.