### PR TITLE
fix: invalid path in dap python configuration.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -349,7 +349,7 @@ function config.dap()
 
 	dap.adapters.python = {
 		type = "executable",
-		command = os.getenv("HOME") .. "/.local/share/nvim/dapinstall/python/bin/python",
+		command = "/usr/bin/python",
 		args = { "-m", "debugpy.adapter" },
 	}
 	dap.configurations.python = {


### PR DESCRIPTION
DAPInstall was replaced by mason and removed in #169 , but the python configuration of nvim-dap stays unchanged. 

The official tutorial [Debug Adapter installation](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#python) recommends using virtual environment, but I think the easiest way is either applying [nvim-dap-python](https://github.com/mfussenegger/nvim-dap-python) or using `/usr/bin/python` by `pip install debugpy` directly. In this PR I use the latter and it works fine in archlinux. What do you think of it?

BTW [wiki](https://github.com/ayamir/nvimdots/wiki/Plugins#editor) also needs to update, but it seems that only repo owner can edit.