### PR TITLE
(temp) fix: Disable Treesitter highlight on help pages.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -27,7 +27,7 @@ function config.nvim_treesitter()
 		},
 		highlight = {
 			enable = true,
-			disable = { "vim" },
+			disable = { "vim", "help" },
 			additional_vim_regex_highlighting = false,
 		},
 		textobjects = {


### PR DESCRIPTION
- Treesitter parser for help doc is currently having some issue for conceal https://github.com/neovim/tree-sitter-vimdoc/issues/23.