### PR TITLE
fix packer bootstraping

### DIFF
--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -116,6 +116,7 @@ function plugins.load_compile()
 	if vim.fn.filereadable(packer_compiled) == 1 then
 		require("_compiled")
 	else
+		plugins.back_compile()
 		assert("Missing packer compile file Run PackerCompile Or PackerInstall to fix")
 	end
 	vim.cmd([[command! PackerCompile lua require('core.pack').back_compile()]])


### PR DESCRIPTION
sometimes `packer.nvim` may fail to cache compiled lua file in data_dir.

This PR ensures the cache file will be compiled.

Signed-off-by: ClSlaid <cailue@bupt.edu.cn>