### PR TITLE
Optimize wsl startup time and sensible python provider config. (branch: 0.8)

### DIFF
--- a/lua/core/global.lua
+++ b/lua/core/global.lua
@@ -5,6 +5,7 @@ function global:load_variables()
 	self.is_mac = os_name == "Darwin"
 	self.is_linux = os_name == "Linux"
 	self.is_windows = os_name == "Windows_NT"
+	self.is_wsl = (vim.fn.has("wsl") == 1)
 	self.vim_path = vim.fn.stdpath("config")
 	local path_sep = self.is_windows and "\\" or "/"
 	local home = self.is_windows and os.getenv("USERPROFILE") or os.getenv("HOME")

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -66,18 +66,27 @@ local neovide_config = function()
 end
 
 local clipboard_config = function()
-	vim.g.clipboard = {
-		name = "win32yank-wsl",
-		copy = {
-			["+"] = "win32yank.exe -i --crlf",
-			["*"] = "win32yank.exe -i --crlf",
-		},
-		paste = {
-			["+"] = "win32yank.exe -o --lf",
-			["*"] = "win32yank.exe -o --lf",
-		},
-		cache_enabled = 0,
-	}
+	if global.is_mac then
+		vim.g.clipboard = {
+			name = "macOS-clipboard",
+			copy = { ["+"] = "pbcopy", ["*"] = "pbcopy" },
+			paste = { ["+"] = "pbpaste", ["*"] = "pbpaste" },
+			cache_enabled = 0,
+		}
+	elseif global.is_wsl then
+		vim.g.clipboard = {
+			name = "win32yank-wsl",
+			copy = {
+				["+"] = "win32yank.exe -i --crlf",
+				["*"] = "win32yank.exe -i --crlf",
+			},
+			paste = {
+				["+"] = "win32yank.exe -o --lf",
+				["*"] = "win32yank.exe -o --lf",
+			},
+			cache_enabled = 0,
+		}
+	end
 end
 
 local load_core = function()
@@ -88,9 +97,7 @@ local load_core = function()
 
 	pack.ensure_plugins()
 	neovide_config()
-	if global.is_windows then
-		clipboard_config()
-	end
+	clipboard_config()
 
 	require("core.options")
 	require("core.mapping")

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -101,13 +101,20 @@ local function load_options()
 		concealcursor = "niv",
 	}
 
-	if global.is_mac then
+	local function isempty(s)
+		return s == nil or s == ""
+	end
+
+	if not isempty(vim.env.CONDA_PREFIX) then
+		vim.g.python3_host_prog = vim.env.CONDA_PREFIX .. "/bin/python"
+	elseif global.is_mac then
 		vim.g.python_host_prog = "/usr/bin/python"
 		vim.g.python3_host_prog = "/usr/local/bin/python3"
 	else
 		vim.g.python_host_prog = "/usr/bin/python"
 		vim.g.python3_host_prog = "/usr/bin/python3"
 	end
+	
 	for name, value in pairs(global_local) do
 		vim.o[name] = value
 	end

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -102,12 +102,6 @@ local function load_options()
 	}
 
 	if global.is_mac then
-		vim.g.clipboard = {
-			name = "macOS-clipboard",
-			copy = { ["+"] = "pbcopy", ["*"] = "pbcopy" },
-			paste = { ["+"] = "pbpaste", ["*"] = "pbpaste" },
-			cache_enabled = 0,
-		}
 		vim.g.python_host_prog = "/usr/bin/python"
 		vim.g.python3_host_prog = "/usr/local/bin/python3"
 	else


### PR DESCRIPTION
Without setting clipboard configs, nvim will spend extra time(~300ms) to find clipboard provider, according to [this reddit post](https://www.reddit.com/r/neovim/comments/ab01n8/improve_neovim_startup_by_60ms_for_free_on_macos/).

This setup improve startup time from ~400ms to ~40ms on my wsl.

And a more sensible python provider config, for conda especially.

OS: Ubuntu 22.04(wsl)
Nvim: 0.8-dev

PS. Sorry for creating so many pr, I'm not quite familiar with branches.