### PR TITLE
fix: efm language server configuration may be overwrite

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -199,7 +199,7 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 				},
 			},
 		})
-	else
+	elseif server ~= "efm" then
 		nvim_lsp[server].setup({
 			capabilities = capabilities,
 			on_attach = custom_attach,


### PR DESCRIPTION
I'm not sure if this is a bug. The configuration of the efm language server configured by efmls-config plugin may be overwrite by the following code as it may call `setup{}` twice according to [nvim-lspconfig#Troubleshooting](https://github.com/neovim/nvim-lspconfig#troubleshooting).
https://github.com/ayamir/nvimdots/blob/efb65fb1c688b7071b6b88602d818db7d44e530d/lua/modules/completion/lsp.lua#L202-L206
Thus, efm language server may launch when edit rust files（In my view，it shouldn't) according to [server_configuration#efm](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#efm).
