### PR TITLE
解决因加载顺序问题导致“mason not found”问题

### DIFF
--- a/lua/modules/completion/plugins.lua
+++ b/lua/modules/completion/plugins.lua
@@ -4,7 +4,7 @@ local conf = require("modules.completion.config")
 completion["neovim/nvim-lspconfig"] = {
 	opt = true,
 	event = "BufReadPre",
-	config = conf.nvim_lsp,
+	-- config = conf.nvim_lsp,
 }
 completion["creativenull/efmls-configs-nvim"] = {
 	opt = false,
@@ -14,6 +14,7 @@ completion["williamboman/mason.nvim"] = {
 	requires = {
 		{
 			"williamboman/mason-lspconfig.nvim",
+			config = conf.nvim_lsp,
 		},
 		{ "WhoIsSethDaniel/mason-tool-installer.nvim", config = conf.mason_install },
 	},
@@ -71,3 +72,4 @@ completion["zbirenbaum/copilot-cmp"] = {
 }
 
 return completion
+


### PR DESCRIPTION
解决因加载顺序问题导致“mason not found”问题，以防止一些用户在添加新插件之后，PackerCompile容易报错的现象

Signed-off-by: cody <admin@nacgame.com>