### PR TITLE
fix: im pick up error

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -435,17 +435,18 @@ end
 function config.imselect()
 	-- fcitx5 need a manual config
 	if vim.fn.executable("fcitx5-remote") == 1 then
-		vim.api.nvim_command([[
-		let g:im_select_get_im_cmd = ["fcitx5-remote"]
-		let g:im_select_default = '1'
-		let g:ImSelectSetImCmd = {
+		vim.api.nvim_command({
+			[[ let g:im_select_get_im_cmd = ["fcitx5-remote"] ]],
+			[[ let g:im_select_default = '1' ]],
+			[[ let g:ImSelectSetImCmd = {
 			\ key ->
 			\ key == 1 ? ['fcitx5-remote', '-c'] :
 			\ key == 2 ? ['fcitx5-remote', '-o'] :
 			\ key == 0 ? ['fcitx5-remote', '-c'] :
 			\ execute("throw 'invalid im key'")
 			\ }
-			]])
+			]],
+		}, { true, true, true })
 	end
 end
 

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -435,7 +435,7 @@ end
 function config.imselect()
 	-- fcitx5 need a manual config
 	if vim.fn.executable("fcitx5-remote") == 1 then
-		vim.api.nvim_command({
+		vim.api.nvim_cmd({
 			[[ let g:im_select_get_im_cmd = ["fcitx5-remote"] ]],
 			[[ let g:im_select_default = '1' ]],
 			[[ let g:ImSelectSetImCmd = {


### PR DESCRIPTION
In the version: NVIM v0.9.0-dev-55-gedc8a1f046, branch 0.8 commit [4a4e9eb](https://github.com/ayamir/nvimdots/commit/4a4e9eb9b3ac1397d0c5e1b40a0998488e4a5d43) will run into an error in this [line](https://github.com/ayamir/nvimdots/blob/4a4e9eb9b3ac1397d0c5e1b40a0998488e4a5d43/lua/modules/editor/config.lua#L442):

Invalid expression on:
```
	let g:ImSelectSetImCmd = {
			\ key ->
                              ^^------ invalid expression
			\ key == 1 ? ['fcitx5-remote', '-c'] :
			\ key == 2 ? ['fcitx5-remote', '-o'] :
			\ key == 0 ? ['fcitx5-remote', '-c'] :
			\ execute("throw 'invalid im key'")
			\ }
			]])
```

It's suggested in neovim's official documentations that using `nvim_cmd` or `nvim_exec` instead of `nvim_command` on multiple lines of Ex commands, and by replacing it I somehow fixed this problem.

Signed-off-by: ClSlaid <cailue@bupt.edu.cn>