### PR TITLE
Make treesitter parser support filetype `sh`.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -72,9 +72,7 @@ function config.nvim_treesitter()
 	end
 	
 	local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-	parser_config.bash.filetype_to_parsername = {
-		"sh", --[["zsh"--]]
-	}
+	parser_config.bash.filetype_to_parsername = { "sh", "zsh" }
 end
 
 function config.illuminate()

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -71,8 +71,10 @@ function config.nvim_treesitter()
 		p.install_info.url = p.install_info.url:gsub("https://github.com/", "git@github.com:")
 	end
 	
-	local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-	parser_config.bash.filetype_to_parsername = { "sh", "zsh" }
+        local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+        parser_config.bash.filetype_to_parsername = {
+            "sh", --[["zsh"--]]
+        }
 end
 
 function config.illuminate()

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -70,6 +70,11 @@ function config.nvim_treesitter()
 	for _, p in pairs(parsers) do
 		p.install_info.url = p.install_info.url:gsub("https://github.com/", "git@github.com:")
 	end
+	
+	local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+	parser_config.bash.filetype_to_parsername = {
+		"sh", --[["zsh"--]]
+	}
 end
 
 function config.illuminate()


### PR DESCRIPTION
For filetypes such as `sh` and files like `.bashrc` use the bash treesitter parser.
1. Why not use `ftdetect/sh.vim`? 
  Although this method can change filetype from `sh` to `bash`, but it has some issues with lazyloading [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp) and [`Luasnip`](https://github.com/L3MON4D3/LuaSnip), I think.
2. Why not use autocommand to change filetype? 
  Same reason as above.

 The error if using `ftdetect/sh.vim` or autocommand to change filetype:
  ```txt
  Error detected while processing BufReadPost Autocommands for "*":
E5108: Error executing lua ...vim/site/pack/packer/opt/packer.nvim/lua/packer/load.lua:171: Vim(echomsg):E114: Missing quote
: "Error in packer_compiled: ...vim/site/pack/packer/opt/packer.nvim/lua/packer/load.lua:160: Vim(append):Error executing lu
a callback: vim/keymap.lua:0: E31: No such mapping
stack traceback:
        [C]: in function 'cmd'
        ...vim/site/pack/packer/opt/packer.nvim/lua/packer/load.lua:171: in function <...vim/site/pack/packer/opt/packer.nvi
m/lua/packer/load.lua:167>
        [string ":lua"]:1: in main chunk
```

`ftdetect/sh.vim`:
```vim
au BufRead,BufNewFile ~/.bashrc,~/.bash_functions,~/.bash_aliases,*.sh set filetype=bash
```

P.S. The error persists if I change the event from `BufRead,BufNewFile` to `VimEnter`, just change from `... processing BufReadPost Autocommands ...` to `... processing VimEnter Autocommands ...`.
