### PR TITLE
feat: update nvim-colorizer.lua to a new fork

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -64,7 +64,7 @@ editor["akinsho/toggleterm.nvim"] = {
 	event = "UIEnter",
 	config = conf.toggleterm,
 }
-editor["norcalli/nvim-colorizer.lua"] = {
+editor["NvChad/nvim-colorizer.lua"] = {
 	opt = true,
 	event = "BufReadPost",
 	config = conf.nvim_colorizer,


### PR DESCRIPTION
For the old one is not maintained. And the NvChad one had included some important merge.