### PR TITLE
feat(ts-help): Enable treesitter highlight on help pages.

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -27,7 +27,7 @@ function config.nvim_treesitter()
 		},
 		highlight = {
 			enable = true,
-			disable = { "vim", "help" },
+			disable = { "vim" },
 			additional_vim_regex_highlighting = false,
 		},
 		textobjects = {


### PR DESCRIPTION
> This issue has been fixed by upstream.