### PR TITLE
chore(lsp): Migrate to `default_capabilities`.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -21,7 +21,7 @@ mason_lsp.setup({
 })
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require("cmp_nvim_lsp").update_capabilities(capabilities)
+capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
 
 local function custom_attach(client, bufnr)
 	require("lsp_signature").on_attach({


### PR DESCRIPTION
`update_caoabilites` is deprecated, use `cmp_nvim_lsp.default_capabilities` instead.

![image](https://user-images.githubusercontent.com/32497323/195989623-a8c824c4-8c84-4571-833f-bbdfd32b3220.png)
