### PR TITLE
fix: not a valid entry warning thrown by mason-lspconfig

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -11,9 +11,9 @@ local mason_lsp = require("mason-lspconfig")
 mason.setup()
 mason_lsp.setup({
 	ensure_installed = {
-		"bash-language-server",
+		"bashls",
 		"efm",
-		"lua-language-server",
+		"sumneko_lua",
 		"clangd",
 		"gopls",
 		"pyright",


### PR DESCRIPTION
A new commit in mason-lspconfig.nvim https://github.com/williamboman/mason-lspconfig.nvim/pull/81 warns about invalid entries in ensure_installed, and I got warnings from `:Notifications` like:

```
Server bash-language-server is not a valid entry in ensure_installed. Make sure to only provide lspconfig server names.
Server lua-language-server is not a valid entry in ensure_installed. Make sure to only provide lspconfig server names.
```

So I replace the server name with name in [available-lsp-servers](https://github.com/williamboman/mason-lspconfig.nvim#available-lsp-servers).