### PR TITLE
feat(script): Support cross-platform installation on *nix.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -123,13 +123,22 @@ check_ssh() {
 
 is_latest() {
 	local nvim_version
-	nvim_version=$(nvim --version | head -n1 | sed -e 's|^[^0-9]*||' -e 's| .*||')
+	nvim_version="$(nvim --version | head -n1 | sed -e 's|^[^0-9]*||' -e 's| .*||')"
 	if version_ge "$(major_minor "${nvim_version##* }")" "$(major_minor "${REQUIRED_NVIM_VERSION}")"; then
 		return 0
 	else
 		return 1
 	fi
 }
+
+if ! command -v perl >/dev/null; then
+	abort "$(
+		cat <<EOABORT
+Perl is required to interpret this script. See:
+  ${tty_underline}https://www.perl.org/get.html${tty_reset}
+EOABORT
+	)"
+fi
 
 if ! command -v nvim >/dev/null; then
 	abort "$(
@@ -190,8 +199,7 @@ cd "${DEST_DIR}" || return
 
 if [ "$USE_SSH" -eq "0" ]; then
 	prompt "Changing default fetching method to HTTPS..."
-	sed -i '' -e 's/\[\"use_ssh\"\] \= true/\[\"use_ssh\"\] \= false/g' "./lua/core/settings.lua"
-	# The -i argument for sed command is a GNU extension. Compatibility issues need to be addressed in the future.
+	execute "perl" "-pi" "-e" "s/\[\"use_ssh\"\] \= true/\[\"use_ssh\"\] \= false/g" "${DEST_DIR}/lua/core/settings.lua"
 fi
 
 prompt "Spawning neovim and fetching plugins... (You'll be redirected shortly)"


### PR DESCRIPTION
**This commit updated the installation script to ensure cross platform-support _(on \*nix)_.**

The details are as follows:
- All pathnames and variables are now enclosed in quotation marks to prevent installation failure due to space(s) in variables.
- **!!** **Replace** the `sed` command with `perl`. AFAIK `perl` is now provided on `MacOS`, `Unix`, and `Linux` _(Linux reference: [LSB Languages Version 5.0](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Languages/LSB-Languages/perllocation.html) and [Download page for Perl](https://www.perl.org/get.html))_. This can address compatibility issues of the `sed` command with `-i` option.

@ayamir @CharlesChiuGit Can you help me test this on Linux? I don't have machines running Linux at hand, but AFAIK `perl` _should_ work correctly on every distribution 👍

```sh
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Jint-lzxy/nvimdots/script-compatibility/install/install.sh)"
```