### PR TITLE
feat(smartynk.nvim): a very smart integrated yank manager

### DIFF
--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -244,4 +244,29 @@ function config.wilder()
 	)
 end
 
+function config.smarkynk()
+	require("smartyank").setup({
+		highlight = {
+			enabled = false, -- highlight yanked text
+			higroup = "IncSearch", -- highlight group of yanked text
+			timeout = 2000, -- timeout for clearing the highlight
+		},
+		clipboard = {
+			enabled = true,
+		},
+		tmux = {
+			enabled = true,
+			-- remove `-w` to disable copy to host client's clipboard
+			cmd = { "tmux", "set-buffer", "-w" },
+		},
+		osc52 = {
+			enabled = true,
+			escseq = "tmux", -- use tmux escape sequence, only enable if you're using remote tmux and have issues (see #4)
+			ssh_only = true, -- false to OSC52 yank also in local sessions
+			silent = false, -- true to disable the "n chars copied" echo
+			echo_hl = "Directory", -- highlight group of the OSC52 echo message
+		},
+	})
+end
+
 return config

--- a/lua/modules/tools/plugins.lua
+++ b/lua/modules/tools/plugins.lua
@@ -48,5 +48,10 @@ tools["gelguy/wilder.nvim"] = {
 	config = conf.wilder,
 	requires = { { "romgrk/fzy-lua-native", after = "wilder.nvim" } },
 }
+tools["ibhagwan/smartyank.nvim"] = {
+	opt = true,
+	event = "BufReadPost",
+	config = conf.smartyank,
+}
 
 return tools


### PR DESCRIPTION
Due to request of #303 .
After some tests and intense discussion(https://github.com/ibhagwan/smartyank.nvim/issues/4) with the plugin author, I think this plugin is ready to make our remote yanking experience better.

This plugin does following things:

1. Auto-detect whether you're in `SSH/ remote TMUX` or not.
2. If you're in bare remote session, auto-sync yanked texts to "remote machine clipboard/local clipboard"
3. If you're in remote tmux session, auto-sync yanked texts to "remote machine clipboard/remote tmux buffer/local clipboard"
4. Highlight yanked texts. (Disabled, since we already have something similar in `core/events.lua`)
5. No extra tool needed! 🎉

NOTE: 

1. If you're using tmux on remote machine, **PLEASE DO** remember to add below lines in your `tmux.conf` if your tmux is **3.3a or higher**. Since `osc52` is off by default since **3.3a**.
```sh
set -g set-clipboard on
setw -g allow-passthrough on
```
2. Avoid using nested tmux sessions, ie, start remote tmux sessions in local tmux sessions. 
3. Remote program/editor must support `osc52`.
4. Local terminal emulator must support `osc52`.


Huge s/o to @ibhagwan for creating this amazing plugin and help me debug along the way!