### PR TITLE
fix(mapping): Resolve conflicting <C-i> and <Tab> mapping.

### DIFF
--- a/lua/core/mapping.lua
+++ b/lua/core/mapping.lua
@@ -6,8 +6,7 @@ local map_cmd = bind.map_cmd
 -- default map
 local def_map = {
 	-- Vim map
-	["n|<Tab>"] = map_cr("normal zc"):with_noremap():with_silent(),
-	["n|<S-Tab>"] = map_cr("normal zo"):with_noremap():with_silent(),
+	["n|<S-Tab>"] = map_cr("normal za"):with_noremap():with_silent(),
 	["n|<C-x>k"] = map_cr("bdelete"):with_noremap():with_silent(),
 	["n|<C-s>"] = map_cu("write"):with_noremap(),
 	["n|Y"] = map_cmd("y$"),

--- a/lua/core/mapping.lua
+++ b/lua/core/mapping.lua
@@ -6,6 +6,8 @@ local map_cmd = bind.map_cmd
 -- default map
 local def_map = {
 	-- Vim map
+	["n|<Tab>"] = map_cr("normal zc"):with_noremap():with_silent(),
+	["n|<S-Tab>"] = map_cr("normal zo"):with_noremap():with_silent(),
 	["n|<C-x>k"] = map_cr("bdelete"):with_noremap():with_silent(),
 	["n|<C-s>"] = map_cu("write"):with_noremap(),
 	["n|Y"] = map_cmd("y$"),


### PR DESCRIPTION
This might be a better solution for #321. With `normal za`, we can still use paragraph folding thru `<S-Tab>`.
Since `CSI u` keycode is not *yet* supported on every terminal, IMO at present, what we can do is to resolve those _conflicting_ keybindings _(\<C-i\> and \<Tab\>)_, rather than completely disable this possibly commonly used feature.

<details>
    <summary><code class="notranslate">:h za</code></summary>
<p>
<div class="highlight highlight-text-shell-session notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-c1">							*za*</span>
<span class="pl-c1">za		When on a closed fold: open it.  When folds are nested, you</span>
<span class="pl-c1">		may have to use "za" several times.  When a count is given,</span>
<span class="pl-c1">		that many closed folds are opened.</span>
<span class="pl-c1">		When on an open fold: close it and set 'foldenable'.  This</span>
<span class="pl-c1">		will only close one level, since using "za" again will open</span>
<span class="pl-c1">		the fold.  When a count is given that many folds will be</span>
<span class="pl-c1">		closed (that's not the same as repeating "za" that many</span>
<span class="pl-c1">		times).</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
    <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="							*za*
za		When on a closed fold: open it.  When folds are nested, you
		may have to use &quot;za&quot; several times.  When a count is given,
		that many closed folds are opened.
		When on an open fold: close it and set 'foldenable'.  This
		will only close one level, since using &quot;za&quot; again will open
		the fold.  When a count is given that many folds will be
		closed (that's not the same as repeating &quot;za&quot; that many
		times)." tabindex="0" role="button" style="display: inherit;">
      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
    <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
</svg>
      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
    <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
</svg>
    </clipboard-copy>
  </div></div>
</details>