### PR TITLE
fix(editor): remove the deprecated plugin

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -48,6 +48,7 @@ local function load_options()
 		whichwrap = "h,l,<,>,[,],~",
 		splitbelow = true,
 		splitright = true,
+		splitkeep = "screen",
 		switchbuf = "useopen",
 		backspace = "indent,eol,start",
 		diffopt = "filler,iwhite,internal,algorithm:patience",

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -121,10 +121,11 @@ editor["sindrets/diffview.nvim"] = {
 	opt = true,
 	cmd = { "DiffviewOpen" },
 }
-editor["luukvbaal/stabilize.nvim"] = {
-	opt = true,
-	event = "BufReadPost",
-}
+-- deprecated see: https://github.com/neovim/neovim/pull/19243
+-- editor["luukvbaal/stabilize.nvim"] = {
+-- 	opt = true,
+-- 	event = "BufReadPost",
+-- }
 editor["ibhagwan/smartyank.nvim"] = {
 	opt = true,
 	event = "BufReadPost",


### PR DESCRIPTION
see: https://github.com/luukvbaal/stabilize.nvim
This plugin has been declared deprecated by the author.
