### PR TITLE
fix(catppuccin): Improve highlight for mocha

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -25,6 +25,7 @@ function config.alpha()
 		[[⠿⠛⠛⠛⠛⠛⠛⠻⢿⣿⣿⣿⣿⣯⣟⠷⢷⣿⡿⠋⠀⠀⠀⠀⣵⡀⢠⡿⠋⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]],
 		[[⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠛⢿⣿⣿⠂⠀⠀⠀⠀⠀⢀⣽⣿⣿⣿⣿⣿⣿⣿⣍⠛⠿⣿⣿⣿⣿⣿⣿]],
 	}
+	dashboard.section.header.opts.hl = "Type"
 
 	local function button(sc, txt, leader_txt, keybind, keybind_opts)
 		local sc_after = sc:gsub("%s", ""):gsub(leader_txt, "<leader>")
@@ -242,6 +243,9 @@ function config.catppuccin()
 					CursorLineNr = { fg = cp.green },
 					Search = { bg = cp.surface1, fg = cp.pink, style = { "bold" } },
 					IncSearch = { bg = cp.pink, fg = cp.surface1 },
+					Keyword = { fg = cp.pink },
+					Type = { fg = cp.blue },
+					Typedef = { fg = cp.yellow, link = "" },
 
 					-- For native lsp configs.
 					DiagnosticVirtualTextError = { bg = cp.none },
@@ -264,7 +268,7 @@ function config.catppuccin()
 					["@property"] = { fg = cp.yellow },
 
 					["@include"] = { fg = cp.teal },
-					["@operator"] = { fg = cp.sky },
+					-- ["@operator"] = { fg = cp.sky },
 					["@keyword.operator"] = { fg = cp.sky },
 					["@punctuation.special"] = { fg = cp.maroon },
 
@@ -286,8 +290,8 @@ function config.catppuccin()
 					-- ["@function"] = { fg = cp.blue },
 					["@function.macro"] = { fg = cp.red, style = {} },
 					["@parameter"] = { fg = cp.rosewater },
+					["@keyword"] = { fg = cp.red, style = { "italic" }, link = "" },
 					["@keyword.function"] = { fg = cp.maroon },
-					["@keyword"] = { fg = cp.red },
 					["@keyword.return"] = { fg = cp.pink, style = {} },
 
 					-- ["@text.note"] = { fg = cp.base, bg = cp.blue },
@@ -303,7 +307,7 @@ function config.catppuccin()
 					["@punctuation.bracket"] = { fg = cp.overlay2 },
 					-- ["@string"] = { fg = cp.green },
 					-- ["@string.regex"] = { fg = cp.peach },
-					-- ["@type"] = { fg = cp.yellow },
+					["@type"] = { fg = cp.yellow, link = "" },
 					["@variable"] = { fg = cp.text },
 					["@tag.attribute"] = { fg = cp.mauve, style = { "italic" } },
 					["@tag"] = { fg = cp.peach },


### PR DESCRIPTION
https://github.com/catppuccin/nvim/commit/d1c3eb0409fc74dc685e6d2a576d2004f0113ab8 introduced these changes, which will affect the appearance of `alpha`. Configs have been adjusted accordingly for `mocha`.