### PR TITLE
fix(plugins): Remove unintended "packadd"

### DIFF
--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -6,7 +6,6 @@ function config.telescope()
 	vim.api.nvim_command([[packadd telescope-project.nvim]])
 	vim.api.nvim_command([[packadd telescope-frecency.nvim]])
 	vim.api.nvim_command([[packadd telescope-zoxide]])
-	vim.api.nvim_command([[packadd telescope-ui-select.nvim]])
 
 	local icons = { ui = require("modules.ui.icons").get("ui", true) }
 	local telescope_actions = require("telescope.actions.set")


### PR DESCRIPTION
`telescope-ui-select.nvim` was removed in [`e8d2c5b`](https://github.com/ayamir/nvimdots/pull/333/commits/e8d2c5b5277b4aa2002f235c5713a1eb0715856d). However, this plugin is still loaded via `packadd` incorrectly.