### PR TITLE
chore(catppuccin): Update highlights

### DIFF
--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -246,6 +246,7 @@ function config.catppuccin()
 					Keyword = { fg = cp.pink },
 					Type = { fg = cp.blue },
 					Typedef = { fg = cp.yellow },
+					StorageClass = { fg = cp.red, style = { "italic" } },
 
 					-- For native lsp configs.
 					DiagnosticVirtualTextError = { bg = cp.none },
@@ -285,6 +286,7 @@ function config.catppuccin()
 					["@constant.builtin"] = { fg = cp.lavender },
 					-- ["@function.builtin"] = { fg = cp.peach, style = { "italic" } },
 					-- ["@type.builtin"] = { fg = cp.yellow, style = { "italic" } },
+					["@type.qualifier"] = { link = "@keyword" },
 					["@variable.builtin"] = { fg = cp.red, style = { "italic" } },
 
 					-- ["@function"] = { fg = cp.blue },


### PR DESCRIPTION
Due to changes in the upstream _(nvim-treesitter)_ highlight groups, I have also modified several highlights for catppuccin to prevent duplication in adjacent highlight groups _(in some cases, they cannot be distinguished at a glance)_, for example:
```cpp
                 static constexpr                          foo                     <int> bar;
                       ↑                                    ↑                        ↑
storage_class_specifier/type_qualifier(yellow)    type_identifier(yellow)   primitive_type(yellow, italic)
```
has been adjusted to:
```cpp
           static constexpr                          foo                     <int> bar;
                 ↑                                    ↑                        ↑
storage_class/type_qualifier(red, italic)    type_identifier(yellow)   primitive_type(yellow, italic)
```
******
### This modification is _non-trivial_. It will affect the syntax highlighting of the following languages:
- blueprint
- C
- C#
- C++
- CSS
- cuda
- D
- dart
- fortran
- gdscript
- gleam
- glsl
- hack
- hlsl
- java
- julia
- kotlin
- lalrpop
- llvm
- mermaid
- ocaml
- pascal
- php
- pioasm
- ql
- qmljs
- rasi
- ruby
- rust
- scala
- solidity
- swift
- typescript
- vala
- verilog
- wgsl
- zig