### PR TITLE
chore(lspsaga): deprecate LSoutlineToggle, use Lspsaga outline instead

### DIFF
--- a/lua/keymap/init.lua
+++ b/lua/keymap/init.lua
@@ -32,7 +32,7 @@ local plug_map = {
 	-- Lsp mapp work when insertenter and lsp start
 	["n|<leader>li"] = map_cr("LspInfo"):with_noremap():with_silent():with_nowait(),
 	["n|<leader>lr"] = map_cr("LspRestart"):with_noremap():with_silent():with_nowait(),
-	["n|<A-t>"] = map_cr("LSoutlineToggle"):with_noremap():with_silent(),
+	["n|go"] = map_cr("Lspsaga outline"):with_noremap():with_silent(),
 	["n|g["] = map_cr("Lspsaga diagnostic_jump_prev"):with_noremap():with_silent(),
 	["n|g]"] = map_cr("Lspsaga diagnostic_jump_next"):with_noremap():with_silent(),
 	["n|gs"] = map_cr("lua vim.lsp.buf.signature_help()"):with_noremap():with_silent(),

--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -377,6 +377,7 @@ function config.legendary()
 			d = "lsp: Preview definition",
 			D = "lsp: Goto definition",
 			h = "lsp: Show reference",
+			o = "lsp: Toggle outline",
 			r = "lsp: Rename",
 			s = "lsp: Signature help",
 			t = "lsp: Toggle trouble list",


### PR DESCRIPTION
see https://github.com/glepnir/lspsaga.nvim/commit/b7b4777369b441341b2dcd45c738ea4167c11c9e