### PR TITLE
chore(colorizer): prevent treesitter to overide background

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -74,7 +74,8 @@ editor["akinsho/toggleterm.nvim"] = {
 }
 editor["NvChad/nvim-colorizer.lua"] = {
 	opt = true,
-	event = "BufReadPost",
+	-- event = "BufReadPost",
+	after = "nvim-treesitter",
 	config = conf.nvim_colorizer,
 }
 editor["rmagatti/auto-session"] = {

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -74,7 +74,6 @@ editor["akinsho/toggleterm.nvim"] = {
 }
 editor["NvChad/nvim-colorizer.lua"] = {
 	opt = true,
-	-- event = "BufReadPost",
 	after = "nvim-treesitter",
 	config = conf.nvim_colorizer,
 }


### PR DESCRIPTION
When one fires nvim, the colored background of the hex values are oftenly being overide by treesitter. Loading colorizer after treesitter provides a more consistent behavior when working with colors.