### PR TITLE
feat(core): hot reload nvim core options

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -15,15 +15,14 @@ end
 
 function autocmd.load_autocmds()
 	local definitions = {
-		packer = {
+		packer = {},
+		bufs = {
 			-- Hot reload nvim core config
 			{
 				"BufWritePost,FileWritePost",
 				"~/.config/nvim/*.lua",
 				[[source % | source $MYVIMRC | redraw! | PackerCompile]],
 			},
-		},
-		bufs = {
 			{ "BufWritePre", "/tmp/*", "setlocal noundofile" },
 			{ "BufWritePre", "COMMIT_EDITMSG", "setlocal noundofile" },
 			{ "BufWritePre", "MERGE_MSG", "setlocal noundofile" },

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -21,7 +21,13 @@ function autocmd.load_autocmds()
 			{
 				"BufWritePost,FileWritePost",
 				"~/.config/nvim/*.lua",
-				[[source % | source $MYVIMRC | redraw! | PackerCompile]],
+				[[source % | source $MYVIMRC | redraw! | lua require("core.pack").back_compile(true)]],
+			},
+			-- Reload Vim script automatically if setlocal autoread
+			{
+				"BufWritePost,FileWritePost",
+				"*.vim",
+				[[nested if &l:autoread > 0 | source <afile> | echo 'source ' . bufname('%') | endif]],
 			},
 			{ "BufWritePre", "/tmp/*", "setlocal noundofile" },
 			{ "BufWritePre", "COMMIT_EDITMSG", "setlocal noundofile" },

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -15,19 +15,15 @@ end
 
 function autocmd.load_autocmds()
 	local definitions = {
-		packer = {},
-		bufs = {
-			-- Reload vim config automatically
-			{
-				"BufWritePost",
-				[[$VIM_PATH/{*.vim,*.yaml,vimrc} nested source $MYVIMRC | redraw]],
-			},
-			-- Reload Vim script automatically if setlocal autoread
+		packer = {
+			-- Hot reload nvim core config
 			{
 				"BufWritePost,FileWritePost",
-				"*.vim",
-				[[nested if &l:autoread > 0 | source <afile> | echo 'source ' . bufname('%') | endif]],
+				"~/.config/nvim/*.lua",
+				[[source % | source $MYVIMRC | redraw! | PackerCompile]],
 			},
+		},
+		bufs = {
 			{ "BufWritePre", "/tmp/*", "setlocal noundofile" },
 			{ "BufWritePre", "COMMIT_EDITMSG", "setlocal noundofile" },
 			{ "BufWritePre", "MERGE_MSG", "setlocal noundofile" },

--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -112,12 +112,15 @@ function plugins.ensure_plugins()
 	Packer:init_ensure_plugins()
 end
 
-function plugins.back_compile()
+---@param disable_notify? any @If this parameter is passed in, prevent the user from being notified
+function plugins.back_compile(disable_notify)
 	if vim.fn.filereadable(packer_compiled) == 1 then
 		os.rename(packer_compiled, bak_compiled)
 	end
 	plugins.compile()
-	vim.notify("Packer Compile Success!", vim.log.levels.INFO, { title = "Success!" })
+	if disable_notify == nil then
+		vim.notify("Packer Compile Success!", vim.log.levels.INFO, { title = "Success!" })
+	end
 end
 
 function plugins.auto_compile()


### PR DESCRIPTION
This autocmd can hot-reload nvim configs when core options being modified. 
Plugins config may or may not work, depends on how plugin read their config.

NOTE: the `~/.config/nvim` must not be a sym-link.