### PR TITLE
Fixups for neodim & notify

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -116,7 +116,7 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 				"clangd",
 				"--background-index",
 				"--pch-storage=memory",
-				-- You MUST set this arg ↓ to your clangd executable location (if not included)!
+				-- You MUST set this arg ↓ to your c/cpp compiler location (if not included)!
 				"--query-driver=/usr/bin/clang++,/usr/bin/**/clang-*,/bin/clang,/bin/clang++,/usr/bin/gcc,/usr/bin/g++",
 				"--clang-tidy",
 				"--all-scopes-completion",

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -389,6 +389,8 @@ function config.notify()
 		on_close = nil,
 		---@usage timeout for notifications in ms, default 5000
 		timeout = 2000,
+		-- @usage User render fps value
+		fps = 30,
 		-- Render function for notifications. See notify-render()
 		render = "default",
 		---@usage highlight behind the window for stages that change opacity

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -356,7 +356,6 @@ function config.catppuccin()
 end
 
 function config.neodim()
-	vim.api.nvim_command([[packadd nvim-treesitter]])
 	local normal_background = vim.api.nvim_get_hl_by_name("Normal", true).background
 	local blend_color = normal_background ~= nil and string.format("#%06x", normal_background) or "#000000"
 	require("neodim").setup({

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -12,6 +12,7 @@ ui["catppuccin/nvim"] = {
 ui["zbirenbaum/neodim"] = {
 	opt = true,
 	event = "LspAttach",
+	requires = "nvim-treesitter",
 	config = conf.neodim,
 }
 ui["rcarriga/nvim-notify"] = {


### PR DESCRIPTION
The commits resolved:
- Dependency problem of `neodim`
- Rephrased ambiguous comments
- Add option for notify

BTW `project.nvim` and `telescope-project.nvim` provide very similar functions. Is it intentional to keep the two plugins installed at the same time?