### PR TITLE
chore(lua-lsp): prevent lua-ts highlighting being overwritten by lua-lsp

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -102,6 +102,8 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 						preloadFileSize = 10000,
 					},
 					telemetry = { enable = false },
+					-- Do not override treesitter lua highlighting with sumneko lua highlighting
+					semantic = { enable = false },
 				},
 			},
 		})


### PR DESCRIPTION
Lsp highlighting is generally slower than treesitter highlighting, which often causes glitter when editing larger files.
TS-highlighting is also more mature and being broadly adopted by most of the plugins, which generally means it's more "prettier".
