### PR TITLE
fix(lsp): use clang default capabilities with utf-16 as the first offsetEncoding option.

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -108,10 +108,16 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 			},
 		})
 	elseif server == "clangd" then
-		local copy_capabilities = capabilities
-		copy_capabilities.offsetEncoding = { "utf-16" }
+		local clangd_capabilities = {
+			textDocument = {
+				completion = {
+					editsNearCursor = true,
+				},
+			},
+			offsetEncoding = { "utf-16", "utf-8" },
+		}
 		nvim_lsp.clangd.setup({
-			capabilities = copy_capabilities,
+			capabilities = clangd_capabilities,
 			single_file_support = true,
 			on_attach = custom_attach,
 			cmd = {

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -108,16 +108,8 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 			},
 		})
 	elseif server == "clangd" then
-		local clangd_capabilities = {
-			textDocument = {
-				completion = {
-					editsNearCursor = true,
-				},
-			},
-			offsetEncoding = { "utf-16", "utf-8" },
-		}
 		nvim_lsp.clangd.setup({
-			capabilities = clangd_capabilities,
+			capabilities = vim.tbl_deep_extend("keep", { offsetEncoding = { "utf-16", "utf-8" } }, capabilities),
 			single_file_support = true,
 			on_attach = custom_attach,
 			cmd = {


### PR DESCRIPTION
I found the default capabilities here: 
https://github.com/neovim/nvim-lspconfig/blob/973aa14d0992df82ff82f714d978a3eb8d676600/lua/lspconfig/server_configurations/clangd.lua#L33
#375 