### PR TITLE
pref: Cleanup unnecessary code

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -17,11 +17,10 @@ function autocmd.load_autocmds()
 	local definitions = {
 		packer = {},
 		bufs = {
-			-- Hot reload nvim core config
+			-- Reload vim config automatically
 			{
-				"BufWritePost,FileWritePost",
-				"~/.config/nvim/*.lua",
-				[[source % | source $MYVIMRC | redraw! | lua require("core.pack").back_compile(true)]],
+				"BufWritePost",
+				[[$VIM_PATH/{*.vim,*.yaml,vimrc} nested source $MYVIMRC | redraw]],
 			},
 			-- Reload Vim script automatically if setlocal autoread
 			{

--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -112,15 +112,12 @@ function plugins.ensure_plugins()
 	Packer:init_ensure_plugins()
 end
 
----@param disable_notify? any @If this parameter is passed in, prevent the user from being notified
-function plugins.back_compile(disable_notify)
+function plugins.back_compile()
 	if vim.fn.filereadable(packer_compiled) == 1 then
 		os.rename(packer_compiled, bak_compiled)
 	end
 	plugins.compile()
-	if disable_notify == nil then
-		vim.notify("Packer Compile Success!", vim.log.levels.INFO, { title = "Success!" })
-	end
+	vim.notify("Packer Compile Success!", vim.log.levels.INFO, { title = "Success!" })
 end
 
 function plugins.auto_compile()

--- a/lua/modules/completion/formatting.lua
+++ b/lua/modules/completion/formatting.lua
@@ -31,7 +31,7 @@ vim.api.nvim_create_user_command("FormatterToggle", function(opts)
 	end
 end, {
 	nargs = 1,
-	complete = function(_, _, _)
+	complete = function()
 		return {
 			"markdown",
 			"vim",
@@ -87,7 +87,7 @@ function M.configure_format_on_save()
 end
 
 function M.toggle_format_on_save()
-	local status, _ = pcall(vim.api.nvim_get_autocmds, {
+	local status = pcall(vim.api.nvim_get_autocmds, {
 		group = "format_on_save",
 		event = "BufWritePre",
 	})

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -120,7 +120,6 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 				"--query-driver=/usr/bin/clang++,/usr/bin/**/clang-*,/bin/clang,/bin/clang++,/usr/bin/gcc,/usr/bin/g++",
 				"--clang-tidy",
 				"--all-scopes-completion",
-				"--cross-file-rename",
 				"--completion-style=detailed",
 				"--header-insertion-decorators",
 				"--header-insertion=iwyu",


### PR DESCRIPTION
This commit revokes the hot-reload feature, removes the settings that `clangd` has deprecated, and cleans up the code.

Related: #377. This would close #375.