### PR TITLE
perf(event): quicker quit

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -74,6 +74,8 @@ function autocmd.load_autocmds()
 			{ "FocusGained", "* checktime" },
 			-- Equalize window dimensions when resizing vim window
 			{ "VimResized", "*", [[tabdo wincmd =]] },
+			-- Silent quit, also quicker
+			{ "VimLeavePre", "*", "silent wall" },
 		},
 		ft = {
 			{ "FileType", "alpha", "set showtabline=0" },

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -75,7 +75,7 @@ function autocmd.load_autocmds()
 			-- Equalize window dimensions when resizing vim window
 			{ "VimResized", "*", [[tabdo wincmd =]] },
 			-- Silent quit, also quicker
-			{ "VimLeavePre", "*", "silent wall" },
+			{ "VimLeavePre", "*", "silent noh" },
 		},
 		ft = {
 			{ "FileType", "alpha", "set showtabline=0" },


### PR DESCRIPTION
nvim-notify causes hanging on quit, use `silent` to prevent hanging.