### PR TITLE
perf: Cleanup legacy code

### DIFF
--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -121,7 +121,6 @@ editor["edluffy/specs.nvim"] = {
 editor["abecodes/tabout.nvim"] = {
 	opt = true,
 	event = "InsertEnter",
-	wants = "nvim-treesitter",
 	after = "nvim-cmp",
 	config = conf.tabout,
 }

--- a/lua/modules/lang/plugins.lua
+++ b/lua/modules/lang/plugins.lua
@@ -11,7 +11,7 @@ lang["simrat39/rust-tools.nvim"] = {
 	opt = true,
 	ft = "rust",
 	config = conf.rust_tools,
-	requires = { { "nvim-lua/plenary.nvim", opt = false } },
+	requires = "nvim-lua/plenary.nvim",
 }
 -- lang["kristijanhusak/orgmode.nvim"] = {
 -- 	opt = true,

--- a/lua/modules/tools/plugins.lua
+++ b/lua/modules/tools/plugins.lua
@@ -1,14 +1,14 @@
 local tools = {}
 local conf = require("modules.tools.config")
 
-tools["nvim-lua/plenary.nvim"] = { opt = false }
+tools["nvim-lua/plenary.nvim"] = { opt = true, module = "plenary" }
 tools["nvim-telescope/telescope.nvim"] = {
 	opt = true,
 	module = "telescope",
 	cmd = "Telescope",
 	config = conf.telescope,
 	requires = {
-		{ "nvim-lua/plenary.nvim", opt = false },
+		"nvim-lua/plenary.nvim",
 		{ "nvim-lua/popup.nvim", opt = true },
 		{ "debugloop/telescope-undo.nvim", opt = true },
 	},

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -12,7 +12,7 @@ ui["catppuccin/nvim"] = {
 ui["zbirenbaum/neodim"] = {
 	opt = true,
 	event = "LspAttach",
-	requires = "nvim-treesitter",
+	requires = "nvim-treesitter/nvim-treesitter",
 	config = conf.neodim,
 }
 ui["rcarriga/nvim-notify"] = {


### PR DESCRIPTION
This commit made the following changes:
- Packer no longer provides the `wants` option, so the corresponding code is deleted;
- Better specify the dependencies of `neodim`;
- Set `plenary` to load on demand