### PR TITLE
feat(lspsaga & lualine): Show symbols in lualine.

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -99,12 +99,11 @@ function config.lspsaga()
 			virtual_text = true,
 		},
 		symbol_in_winbar = {
+			in_custom = true,
 			enable = true,
-			in_custom = false,
 			separator = " " .. icons.ui.Separator,
-			show_file = true,
+			show_file = false,
 			click_support = function(node, clicks, button, modifiers)
-				-- To see all avaiable details: vim.pretty_print(node)
 				local st = node.range.start
 				local en = node.range["end"]
 				if button == "l" then
@@ -115,8 +114,8 @@ function config.lspsaga()
 					end
 				elseif button == "r" then
 					if modifiers == "s" then
-						print("lspsaga") -- shift right click to print "lspsaga"
-					end -- jump to node's ending line+char
+						print("symbol_winbar")
+					end
 					vim.fn.cursor(en.line + 1, en.character + 1)
 				elseif button == "m" then
 					-- middle click to visual select node

--- a/lua/modules/completion/plugins.lua
+++ b/lua/modules/completion/plugins.lua
@@ -21,7 +21,7 @@ completion["williamboman/mason.nvim"] = {
 }
 completion["glepnir/lspsaga.nvim"] = {
 	opt = true,
-	event = "LspAttach",
+	after = "nvim-lspconfig",
 	config = conf.lspsaga,
 }
 completion["ray-x/lsp_signature.nvim"] = { opt = true, after = "nvim-lspconfig" }

--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -225,8 +225,7 @@ function config.wilder()
 		),
 	})
 
-	local string_fg = vim.api.nvim_get_hl_by_name("String", true).foreground
-	local match_hl = string_fg ~= nil and string.format("#%06x", string_fg) or "#ABE9B3"
+	local match_hl = require("modules.utils").hlToRgb("String", false, "#ABE9B3")
 
 	local popupmenu_renderer = wilder.popupmenu_renderer(wilder.popupmenu_border_theme({
 		border = "rounded",

--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -225,7 +225,7 @@ function config.wilder()
 		),
 	})
 
-	local match_hl = require("modules.utils").hlToRgb("String", false, "#ABE9B3")
+	local match_hl = require("modules.utils").hl_to_rgb("String", false, "#ABE9B3")
 
 	local popupmenu_renderer = wilder.popupmenu_renderer(wilder.popupmenu_border_theme({
 		border = "rounded",

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -361,7 +361,7 @@ end
 
 function config.neodim()
 	vim.api.nvim_command([[packadd nvim-treesitter]])
-	local blend_color = require("modules.utils").hlToRgb("Normal", true, "#000000")
+	local blend_color = require("modules.utils").hl_to_rgb("Normal", true)
 
 	require("neodim").setup({
 		alpha = 0.45,
@@ -580,7 +580,7 @@ function config.lualine()
 	})
 
 	-- Properly set background color for lspsaga
-	local winbar_bg = require("modules.utils").hlToRgb("StatusLine", true, "#000000")
+	local winbar_bg = require("modules.utils").hl_to_rgb("StatusLine", true, "#000000")
 	require("modules.utils").extend_hl("LspSagaWinbarSep", { bg = winbar_bg })
 	for _, hlGroup in pairs(require("lspsaga.lspkind")) do
 		require("modules.utils").extend_hl("LspSagaWinbar" .. hlGroup[1], { bg = winbar_bg })

--- a/lua/modules/ui/icons.lua
+++ b/lua/modules/ui/icons.lua
@@ -29,7 +29,7 @@ local data = {
 		TypeParameter = "",
 		Unit = "",
 		Value = "",
-		Variable = "",
+		Variable = "",
 		-- ccls-specific icons.
 		TypeAlias = "",
 		Parameter = "",

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -21,7 +21,7 @@ ui["rcarriga/nvim-notify"] = {
 }
 ui["hoob3rt/lualine.nvim"] = {
 	opt = true,
-	after = "nvim-lspconfig",
+	after = { "nvim-lspconfig", "lspsaga.nvim" },
 	config = conf.lualine,
 }
 ui["goolord/alpha-nvim"] = {

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -6,6 +6,7 @@ local function hexToRgb(c)
 	return { tonumber(c:sub(2, 3), 16), tonumber(c:sub(4, 5), 16), tonumber(c:sub(6, 7), 16) }
 end
 
+--- Blend foreground with background
 ---@param foreground string @The foreground color
 ---@param background string @The background color to blend with
 ---@param alpha number|string @Number between 0 and 1 for blending amount.
@@ -27,29 +28,53 @@ end
 ---@param use_bg boolean @Returns background or not
 ---@param fallback_hl? string @Fallback value if the hl group is not defined
 ---@return string
-function M.hlToRgb(hl_group, use_bg, fallback_hl)
-	fallback_hl = fallback_hl or "#D9E0ED"
+function M.hl_to_rgb(hl_group, use_bg, fallback_hl)
+	local hex = fallback_hl or "#000000"
+	local hlexists = M.tobool(tonumber(vim.api.nvim_exec('echo hlexists("' .. hl_group .. '")', true)))
 
-	if use_bg == true then
-		local color = vim.api.nvim_get_hl_by_name(hl_group, true).background
-		local hex = color ~= nil and string.format("#%06x", color) or fallback_hl
+	if use_bg then
+		if hlexists then
+			hex = string.format("#%06x", vim.api.nvim_get_hl_by_name(hl_group, true).background)
+		end
 		return hex
 	else
-		local color = vim.api.nvim_get_hl_by_name(hl_group, true).foreground
-		local hex = color ~= nil and string.format("#%06x", color) or fallback_hl
+		if hlexists then
+			hex = string.format("#%06x", vim.api.nvim_get_hl_by_name(hl_group, true).foreground)
+		end
 		return hex
 	end
 end
 
+--- Extend a highlight group
+---@param name string @Target highlight group name
+---@param def table @Attributes to be extended
 function M.extend_hl(name, def)
 	local current_def = vim.api.nvim_get_hl_by_name(name, true)
 	if current_def == nil then
 		-- Do nothing if highlight group not found
 		return
 	end
-	local combined_def = vim.tbl_extend("force", current_def, def)
+	local combined_def = vim.tbl_deep_extend("force", current_def, def)
 
 	vim.api.nvim_set_hl(0, name, combined_def)
+end
+
+--- Convert number (0/1) to boolean
+---@param value number? @The value to check, can be nil (API Error)
+---@return boolean|nil
+function M.tobool(value)
+	if value == 0 or value == nil then
+		return false
+	elseif value == 1 then
+		return true
+	else
+		vim.notify(
+			"Attempt to convert data of type '" .. type(value) .. "' [other than 0 or 1] to boolean",
+			vim.log.levels.ERROR,
+			{ title = "[utils] Runtime error" }
+		)
+		return nil
+	end
 end
 
 return M

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -1,0 +1,55 @@
+local M = {}
+
+---@param c string @The color in hexadecimal.
+local function hexToRgb(c)
+	c = string.lower(c)
+	return { tonumber(c:sub(2, 3), 16), tonumber(c:sub(4, 5), 16), tonumber(c:sub(6, 7), 16) }
+end
+
+---@param foreground string @The foreground color
+---@param background string @The background color to blend with
+---@param alpha number|string @Number between 0 and 1 for blending amount.
+function M.blend(foreground, background, alpha)
+	alpha = type(alpha) == "string" and (tonumber(alpha, 16) / 0xff) or alpha
+	local bg = hexToRgb(background)
+	local fg = hexToRgb(foreground)
+
+	local blendChannel = function(i)
+		local ret = (alpha * fg[i] + ((1 - alpha) * bg[i]))
+		return math.floor(math.min(math.max(0, ret), 255) + 0.5)
+	end
+
+	return string.format("#%02x%02x%02x", blendChannel(1), blendChannel(2), blendChannel(3))
+end
+
+--- Get RGB highlight by highlight group
+---@param hl_group string @Highlight group name
+---@param use_bg boolean @Returns background or not
+---@param fallback_hl? string @Fallback value if the hl group is not defined
+---@return string
+function M.hlToRgb(hl_group, use_bg, fallback_hl)
+	fallback_hl = fallback_hl or "#D9E0ED"
+
+	if use_bg == true then
+		local color = vim.api.nvim_get_hl_by_name(hl_group, true).background
+		local hex = color ~= nil and string.format("#%06x", color) or fallback_hl
+		return hex
+	else
+		local color = vim.api.nvim_get_hl_by_name(hl_group, true).foreground
+		local hex = color ~= nil and string.format("#%06x", color) or fallback_hl
+		return hex
+	end
+end
+
+function M.extend_hl(name, def)
+	local current_def = vim.api.nvim_get_hl_by_name(name, true)
+	if current_def == nil then
+		-- Do nothing if highlight group not found
+		return
+	end
+	local combined_def = vim.tbl_extend("force", current_def, def)
+
+	vim.api.nvim_set_hl(0, name, combined_def)
+end
+
+return M


### PR DESCRIPTION
https://github.com/ayamir/nvimdots/issues/398#issuecomment-1370423444. This can solve rendering problems such as displaying `'cursorcolumn'`. Symbol_in_winbar will cause the space between bufferline and the file to be inaccessible by built-in features.

This is a rough setup and should require additional testing 👍 