### PR TITLE
chore(catppuccin): Update highlights

### DIFF
--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -37,7 +37,9 @@ local function custom_attach(client, bufnr)
 		fix_pos = true,
 		hint_enable = true,
 		hi_parameter = "Search",
-		handler_opts = { "double" },
+		handler_opts = {
+			border = "rounded",
+		},
 	})
 end
 

--- a/lua/modules/lang/config.lua
+++ b/lua/modules/lang/config.lua
@@ -21,7 +21,9 @@ function config.rust_tools()
 					fix_pos = true,
 					hint_enable = true,
 					hi_parameter = "Search",
-					handler_opts = { "double" },
+					handler_opts = {
+						border = "rounded",
+					},
 				})
 			end,
 

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -244,6 +244,7 @@ function config.catppuccin()
 			mocha = function(cp)
 				return {
 					-- For base configs.
+					NormalFloat = { fg = cp.text, bg = cp.base },
 					CursorLineNr = { fg = cp.green },
 					Search = { bg = cp.surface1, fg = cp.pink, style = { "bold" } },
 					IncSearch = { bg = cp.pink, fg = cp.surface1 },
@@ -350,7 +351,10 @@ function config.catppuccin()
 					["@type.css"] = { fg = cp.lavender },
 					["@property.css"] = { fg = cp.yellow, style = { "italic" } },
 
+					["@type.builtin.c"] = { fg = cp.yellow, style = {} },
+
 					["@property.cpp"] = { fg = cp.text },
+					["@type.builtin.cpp"] = { fg = cp.yellow, style = {} },
 
 					-- ["@symbol"] = { fg = cp.flamingo },
 				}

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -124,6 +124,8 @@ function config.nord()
 end
 
 function config.catppuccin()
+	local transparent_background = false -- Set background transparency here!
+
 	require("catppuccin").setup({
 		flavour = "mocha", -- Can be one of: latte, frappe, macchiato, mocha
 		background = { light = "latte", dark = "mocha" },
@@ -134,7 +136,7 @@ function config.catppuccin()
 			shade = "dark",
 			percentage = 0.15,
 		},
-		transparent_background = false,
+		transparent_background = transparent_background,
 		term_colors = true,
 		compile_path = vim.fn.stdpath("cache") .. "/catppuccin",
 		styles = {
@@ -244,7 +246,7 @@ function config.catppuccin()
 			mocha = function(cp)
 				return {
 					-- For base configs.
-					NormalFloat = { fg = cp.text, bg = cp.base },
+					NormalFloat = { fg = cp.text, bg = transparent_background and cp.none or cp.base },
 					CursorLineNr = { fg = cp.green },
 					Search = { bg = cp.surface1, fg = cp.pink, style = { "bold" } },
 					IncSearch = { bg = cp.pink, fg = cp.surface1 },


### PR DESCRIPTION
This commit adjusted some highlights for `catppuccin`, namely:
- The background of floating window (`NormalFloat`) is set to be the same as the main background _(because we added border for all floating window, setting the same color can make color matching more consistent)_;
- The _italic_ attribute of the built-in type of `C/C++` is **disabled** to keep it consistent with the user-defined type;
- _(misc)_ Add border for `lsp_signature`.

**Effect:**
- `lsp_signature`:
<img width="962" alt="lsp-signature" src="https://user-images.githubusercontent.com/50296129/210551616-a624658e-3651-4169-b025-417d66b8ed90.png">  

- Floating window:
<img width="1493" alt="normalfloat" src="https://user-images.githubusercontent.com/50296129/210551560-4341b615-b737-454b-8814-2366c614793a.png">
