### PR TITLE
perf(copilot): disable `panel` & `suggestion` for it can interfere `copilot-cmp`

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -348,6 +348,18 @@ end
 function config.copilot()
 	vim.defer_fn(function()
 		require("copilot").setup({
+			cmp = {
+				enabled = true,
+				method = "getCompletionsCycling",
+			},
+			panel = {
+				-- if true, it can interfere with completions in copilot-cmp
+				enabled = false,
+			},
+			suggestion = {
+				-- if true, it can interfere with completions in copilot-cmp
+				enabled = false,
+			},
 			filetypes = {
 				["dap-repl"] = false,
 			},


### PR DESCRIPTION
`panel` and `suggestion` are default to true.
Also, the copilot suggestion in cmp seems faster after setting it to false.
ref: https://github.com/zbirenbaum/copilot-cmp/commit/b732a58ac8b7287b981cd9f0d9c0f61e5e9d5760