### PR TITLE
fix(nvim-tree): Replace alpha with the target file

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -31,7 +31,7 @@ vim.api.nvim_create_autocmd("BufEnter", {
 
 function autocmd.load_autocmds()
 	local definitions = {
-		packer = {},
+		lazy = {},
 		bufs = {
 			-- Reload vim config automatically
 			{

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -110,7 +110,7 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 			on_attach = custom_attach,
 			settings = {
 				Lua = {
-					diagnostics = { globals = { "vim", "packer_plugins" } },
+					diagnostics = { globals = { "vim" } },
 					workspace = {
 						library = {
 							[vim.fn.expand("$VIMRUNTIME/lua")] = true,

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -98,7 +98,6 @@ function config.illuminate()
 			"norg",
 			"NvimTree",
 			"Outline",
-			"packer",
 			"toggleterm",
 		},
 		under_cursor = false,

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -738,7 +738,7 @@ function config.nvim_tree()
 					chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
 					picker = require("window-picker").pick_window,
 					exclude = {
-						filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame" },
+						filetype = { "notify", "qf", "diff", "fugitive", "fugitiveblame" },
 						buftype = { "nofile", "terminal", "help" },
 					},
 				},
@@ -941,7 +941,6 @@ function config.indent_blankline()
 			"log",
 			"fugitive",
 			"gitcommit",
-			"packer",
 			"vimwiki",
 			"markdown",
 			"json",

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -736,7 +736,6 @@ function config.nvim_tree()
 				window_picker = {
 					enable = true,
 					chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
-					picker = require("window-picker").pick_window,
 					exclude = {
 						filetype = { "notify", "qf", "diff", "fugitive", "fugitiveblame" },
 						buftype = { "terminal", "help" },

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -625,7 +625,7 @@ function config.nvim_tree()
 		hijack_netrw = true,
 		hijack_unnamed_buffer_when_opening = true,
 		ignore_buffer_on_setup = false,
-		open_on_setup = false,
+		open_on_setup = true,
 		open_on_setup_file = false,
 		open_on_tab = false,
 		sort_by = "name",
@@ -739,7 +739,7 @@ function config.nvim_tree()
 					picker = require("window-picker").pick_window,
 					exclude = {
 						filetype = { "notify", "qf", "diff", "fugitive", "fugitiveblame" },
-						buftype = { "nofile", "terminal", "help" },
+						buftype = { "terminal", "help" },
 					},
 				},
 			},

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -44,13 +44,6 @@ ui["nvim-tree/nvim-tree.lua"] = {
 		"NvimTreeRefresh",
 	},
 	config = conf.nvim_tree,
-	dependencies = {
-		"s1n7ax/nvim-window-picker",
-		version = "v1.*",
-		config = function()
-			require("window-picker").setup()
-		end,
-	},
 }
 ui["lewis6991/gitsigns.nvim"] = {
 	lazy = true,


### PR DESCRIPTION
Fixes #391.

The source of the problem is that `alpha` sets `opt_local.buftype = "nofile"`, which will prevent `nvim-tree` from replacing it _(as `nofile` is in the exclusion list)_.  Someone in the `alpha-nvim` repo has once opened an issue _(https://github.com/goolord/alpha-nvim/issues/114)_, but it has never been resolved.
Detail: https://github.com/ayamir/nvimdots/issues/391#issuecomment-1405086281.

Note: We may need to add some filetypes to the list since the buffers of plugins such as `Man.lua` will be recognized, but they should never be replaced IMO.