### PR TITLE
fix(tabout): Unset default keymap

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -513,8 +513,8 @@ end
 
 function config.tabout()
 	require("tabout").setup({
-		tabkey = "<Tab>", -- key to trigger tabout, set to an empty string to disable
-		backwards_tabkey = "<S-Tab>", -- key to trigger backwards tabout, set to an empty string to disable
+		tabkey = "", -- key to trigger tabout, set to an empty string to disable
+		backwards_tabkey = "", -- key to trigger backwards tabout, set to an empty string to disable
 		act_as_tab = true, -- shift content if tab out is not possible
 		act_as_shift_tab = false, -- reverse shift content if tab out is not possible (if your keyboard/terminal supports <S-Tab>)
 		enable_backwards = true,

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -330,7 +330,7 @@ function config.catppuccin()
 					-- ["@constant.macro"] = { fg = cp.mauve },
 
 					-- ["@label"] = { fg = cp.blue },
-					["@method"] = { style = { "italic" } },
+					["@method"] = { fg = cp.blue, style = { "italic" } },
 					["@namespace"] = { fg = cp.rosewater, style = {} },
 
 					["@punctuation.delimiter"] = { fg = cp.teal },
@@ -625,7 +625,7 @@ function config.nvim_tree()
 		hijack_netrw = true,
 		hijack_unnamed_buffer_when_opening = true,
 		ignore_buffer_on_setup = false,
-		open_on_setup = true,
+		open_on_setup = false,
 		open_on_setup_file = false,
 		open_on_tab = false,
 		sort_by = "name",


### PR DESCRIPTION
Already defined in `keymap/init.lua`:
https://github.com/ayamir/nvimdots/blob/4327d800db8b9b3777fd8200b5f8bb95ef1e35e1/lua/keymap/init.lua#L143-L145

The default keymap conflicts with `nvim-cmp`.