### PR TITLE
chore(lspsaga & catppuccin): Migrate to v0.2.4.

### DIFF
--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -33,7 +33,7 @@ function config.lspsaga()
 	require("lspsaga").setup({
 		preview = {
 			lines_above = 1,
-			lines_below = 12,
+			lines_below = 17,
 		},
 		scroll_preview = {
 			scroll_down = "<C-j>",
@@ -63,16 +63,16 @@ function config.lspsaga()
 			},
 		},
 		lightbulb = {
-			enable = false,
+			enable = true,
 			sign = true,
 			enable_in_insert = true,
 			sign_priority = 20,
-			virtual_text = true,
+			virtual_text = false,
 		},
 		diagnostic = {
-			twice_into = false,
 			show_code_action = false,
 			show_source = true,
+			jump_num_shortcut = true,
 			keys = {
 				exec_action = "<CR>",
 				quit = "q",
@@ -81,9 +81,9 @@ function config.lspsaga()
 		},
 		rename = {
 			quit = "<C-c>",
-			exec = "<CR>",
 			mark = "x",
 			confirm = "<CR>",
+			exec = "<CR>",
 			in_select = true,
 		},
 		outline = {
@@ -108,6 +108,10 @@ function config.lspsaga()
 			show_file = false,
 			color_mode = true,
 		},
+		beacon = {
+			enable = true,
+			frequency = 12,
+		},
 		ui = {
 			theme = "round",
 			border = "single", -- Can be single, double, rounded, solid, shadow.
@@ -119,28 +123,13 @@ function config.lspsaga()
 			diagnostic = icons.ui.Bug,
 			incoming = icons.ui.Incoming,
 			outgoing = icons.ui.Outgoing,
-			colors = {
-				normal_bg = colors.base,
-				title_bg = colors.base,
-				red = colors.red,
-				megenta = colors.maroon,
-				orange = colors.peach,
-				yellow = colors.yellow,
-				green = colors.green,
-				cyan = colors.sapphire,
-				blue = colors.blue,
-				purple = colors.mauve,
-				white = colors.text,
-				black = colors.mantle,
-				fg = colors.text,
-			},
 			kind = {
 				-- Kind
 				Class = { icons.kind.Class, colors.yellow },
 				Constant = { icons.kind.Constant, colors.peach },
 				Constructor = { icons.kind.Constructor, colors.sapphire },
 				Enum = { icons.kind.Enum, colors.yellow },
-				EnumMember = { icons.kind.EnumMember, colors.rosewater },
+				EnumMember = { icons.kind.EnumMember, colors.teal },
 				Event = { icons.kind.Event, colors.yellow },
 				Field = { icons.kind.Field, colors.teal },
 				File = { icons.kind.File, colors.rosewater },

--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -63,7 +63,7 @@ function config.lspsaga()
 			},
 		},
 		lightbulb = {
-			enable = true,
+			enable = false,
 			sign = true,
 			enable_in_insert = true,
 			sign_priority = 20,

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -268,13 +268,13 @@ function config.catppuccin()
 				CodeActionText = { fg = cp.green },
 				CodeActionNumber = { fg = cp.pink },
 
-				FinderSelection = { fg = cp.blue, bold = true },
+				FinderSelection = { fg = cp.blue, style = { "bold" } },
 				FinderFileName = { fg = cp.text },
 				FinderIcon = { fg = cp.sky },
 				FinderType = { fg = cp.mauve },
 
-				FinderSpinnerTitle = { fg = cp.mauve, bold = true },
-				FinderSpinner = { fg = cp.mauve, bold = true },
+				FinderSpinnerTitle = { fg = cp.mauve, style = { "bold" } },
+				FinderSpinner = { fg = cp.mauve, style = { "bold" } },
 
 				RenameNormal = { fg = cp.text },
 

--- a/lua/modules/ui/config.lua
+++ b/lua/modules/ui/config.lua
@@ -254,13 +254,43 @@ function config.catppuccin()
 				crust = "#161320",
 			},
 		},
+		custom_highlights = function(cp)
+			return {
+				-- For lspsaga.nvim
+				TitleString = { fg = cp.text },
+				TitleIcon = { fg = cp.red },
+				SagaBorder = { fg = cp.blue, bg = cp.none },
+				SagaNormal = { bg = cp.base },
+				SagaExpand = { fg = cp.green },
+				SagaCollapse = { fg = cp.green },
+				SagaBeacon = { bg = cp.surface0 },
+
+				CodeActionText = { fg = cp.green },
+				CodeActionNumber = { fg = cp.pink },
+
+				FinderSelection = { fg = cp.blue, bold = true },
+				FinderFileName = { fg = cp.text },
+				FinderIcon = { fg = cp.sky },
+				FinderType = { fg = cp.mauve },
+
+				FinderSpinnerTitle = { fg = cp.mauve, bold = true },
+				FinderSpinner = { fg = cp.mauve, bold = true },
+
+				RenameNormal = { fg = cp.text },
+
+				DiagnosticSource = { fg = cp.surface2 },
+				DiagnosticPos = { fg = cp.surface2 },
+				DiagnosticWord = { fg = cp.text },
+
+				CallHierarchyIcon = { fg = cp.mauve },
+				CallHierarchyTitle = { fg = cp.blue },
+
+				SagaShadow = { bg = cp.crust },
+
+				OutlineIndent = { fg = cp.surface1 },
+			}
+		end,
 		highlight_overrides = {
-			all = function(cp)
-				return {
-					-- For lspsaga.nvim
-					SagaBeacon = { bg = cp.surface0 },
-				}
-			end,
 			mocha = function(cp)
 				return {
 					-- For base configs.


### PR DESCRIPTION
This commit makes the config compatible with `lspsaga`@v0.2.4.

Major changes include:
- Codeaction icon is enabled in the sidebar.
- Custom colors are no longer supported, so they have been removed.
- Since the current highlight groups are stable _(they shouldn't change much in the future)_, appropriate configs have been applied for catppuccin-lspsaga.