### PR TITLE
fix(script-win): Typo

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -129,7 +129,7 @@ function Check-Def-Exec ([Parameter(Mandatory = $True)][ValidateNotNullOrEmpty()
 
 function Query-Pack {
 	if ((Check-Def-Exec -WithName "scoop") -and (Check-Def-Exec -WithName "choco")) {
-		prompt -Msg "   [Detected] Multiple package mgrs detected."
+		prompt -Msg "   [Detected] Multiple package managers detected."
 
 		$_title = "Package manager Preferences"
 		$_message = "Pick your favorite package manager"
@@ -166,7 +166,7 @@ Avaliable choices are:
 }
 
 function Init-Pack {
-	prompt -Msg "Intializing package manager preferences..."
+	prompt -Msg "Initializing package manager preferences..."
 	if ($env:CCPACK_MGR -ne 'unknown') {
 		prompt -Msg '$env:CCPACK_MGR already defined. Validating...'
 		if (($env:CCPACK_MGR -eq 'choco') -and (Check-Def-Exec -WithName $env:CCPACK_MGR)) {


### PR DESCRIPTION
Also a side note:
> 使用chocolatey安装必要的依赖，下载相应的安装包时会检测系统代理，因为大多是从github下载，所以最好开启系统代理。
> _(From `zhihu`)_

In fact, users can choose to use `chocolatey` or `scoop` to fetch deps. TBH, I see more people using `scoop` so I decided to support both of them.

IMO it would be better to address that the script also supports `scoop` _(and users must install one of them before invoking the script)_, otherwise it may lead to confusion. _(ppl probably won't read the code before installation)_