### PR TITLE
fix(script-win): Avoid prompting for user input when failed

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -5,8 +5,6 @@
 
 Set-StrictMode -Version 3.0
 
-$ErrorActionPreference = "Stop" # Exit when command fails
-
 # global-scope vars
 $REQUIRED_NVIM_VERSION = [version]'0.8.0'
 $USE_SSH = $True


### PR DESCRIPTION
This should eliminate that weird message showing:
```console
cmdlet prompt at command pipeline position 1

Supply values for the following parameters:
Msg:
```

@ayamir @CharlesChiuGit  I would be most grateful if you could test this fix _(let the program exit abnormally, calling `_abort`)_