### PR TITLE
refactor: use on_attach to set mapping

### DIFF
--- a/lua/modules/configs/ui/gitsigns.lua
+++ b/lua/modules/configs/ui/gitsigns.lua
@@ -32,30 +32,65 @@ return function()
 				linehl = "GitSignsChangeLn",
 			},
 		},
-		keymaps = {
-			-- Default keymap options
-			noremap = true,
-			buffer = true,
-			["n ]g"] = {
-				expr = true,
-				"&diff ? ']g' : '<cmd>lua require\"gitsigns\".next_hunk()<CR>'",
-			},
-			["n [g"] = {
-				expr = true,
-				"&diff ? '[g' : '<cmd>lua require\"gitsigns\".prev_hunk()<CR>'",
-			},
-			["n <leader>hs"] = '<cmd>lua require"gitsigns".stage_hunk()<CR>',
-			["v <leader>hs"] = '<cmd>lua require"gitsigns".stage_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
-			["n <leader>hu"] = '<cmd>lua require"gitsigns".undo_stage_hunk()<CR>',
-			["n <leader>hr"] = '<cmd>lua require"gitsigns".reset_hunk()<CR>',
-			["v <leader>hr"] = '<cmd>lua require"gitsigns".reset_hunk({vim.fn.line("."), vim.fn.line("v")})<CR>',
-			["n <leader>hR"] = '<cmd>lua require"gitsigns".reset_buffer()<CR>',
-			["n <leader>hp"] = '<cmd>lua require"gitsigns".preview_hunk()<CR>',
-			["n <leader>hb"] = '<cmd>lua require"gitsigns".blame_line({full=true})<CR>',
-			-- Text objects
-			["o ih"] = ':<C-U>lua require"gitsigns".text_object()<CR>',
-			["x ih"] = ':<C-U>lua require"gitsigns".text_object()<CR>',
-		},
+		on_attach = function(bufnr)
+			local bind = require("keymap.bind")
+
+			bind.nvim_load_mapping({
+				["n|]g"] = bind.map_callback(function()
+					if vim.wo.diff then
+						return "]g"
+					end
+					vim.schedule(function()
+						require("gitsigns.actions").next_hunk()
+					end)
+					return "<Ignore>"
+				end)
+					:with_buffer(bufnr)
+					:with_expr(),
+				["n|[g"] = bind.map_callback(function()
+					if vim.wo.diff then
+						return "[g"
+					end
+					vim.schedule(function()
+						require("gitsigns.actions").prev_hunk()
+					end)
+					return "<Ignore>"
+				end)
+					:with_buffer(bufnr)
+					:with_expr(),
+				["n|<Space>hs"] = bind.map_callback(function()
+					require("gitsigns.actions").stage_hunk()
+				end):with_buffer(bufnr),
+				["v|<Space>hs"] = bind.map_callback(function()
+					require("gitsigns.actions").stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+				end):with_buffer(bufnr),
+				["n|<Space>hu"] = bind.map_callback(function()
+					require("gitsigns.actions").undo_stage_hunk()
+				end):with_buffer(bufnr),
+				["n|<Space>hr"] = bind.map_callback(function()
+					require("gitsigns.actions").reset_hunk()
+				end):with_buffer(bufnr),
+				["v|<Space>hr"] = bind.map_callback(function()
+					require("gitsigns.actions").reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+				end):with_buffer(bufnr),
+				["n|<Space>hR"] = bind.map_callback(function()
+					require("gitsigns.actions").reset_buffer()
+				end):with_buffer(bufnr),
+				["n|<Space>hp"] = bind.map_callback(function()
+					require("gitsigns.actions").preview_hunk()
+				end):with_buffer(bufnr),
+				["n|<Space>hb"] = bind.map_callback(function()
+					require("gitsigns.actions").blame_line({ full = true })
+				end):with_buffer(bufnr),
+				-- Text objects
+				["o|ih"] = bind.map_callback(function()
+					require("gitsigns.actions").text_object()
+				end):with_buffer(bufnr),
+				["x|ih"] = bind.map_callback(function()
+					require("gitsigns.actions").text_object()
+				end):with_buffer(bufnr),
+			})
+		end,
 		watch_gitdir = { interval = 1000, follow_files = true },
 		current_line_blame = true,
 		current_line_blame_opts = { delay = 1000, virtual_text_pos = "eol" },


### PR DESCRIPTION
This PR refactor current gitsigns config, that for setting up key binding we can use `on_attach`

This makes better customization flow as we can access to vim.fn

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
