### PR TITLE
feat: Use CursorHold* to improve startup time

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,18 +1,3 @@
 if not vim.g.vscode then
 	require("core")
-
-	-- Release note
-	vim.schedule(function()
-		vim.notify_once(
-			[[
-We've released version v2.0.0!
-This is a backward-incompatible release. See the release notes for instructions on how to migrate your configs.
-
-Visit https://github.com/ayamir/nvimdots/releases to see the release notes.
-
-To silence this message, remove it from `init.lua` at root directory!
-]],
-			vim.log.levels.WARN
-		)
-	end)
 end

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -87,7 +87,7 @@ local function load_options()
 		ttimeoutlen = 0,
 		undodir = global.cache_dir .. "undo/",
 		undofile = true,
-		updatetime = 100,
+		updatetime = 200,
 		viewoptions = "folds,cursor,curdir,slash,unix",
 		virtualedit = "block",
 		visualbell = true,

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -87,6 +87,7 @@ local function load_options()
 		ttimeoutlen = 0,
 		undodir = global.cache_dir .. "undo/",
 		undofile = true,
+		-- Please do NOT set `updatetime` to above 500, otherwise most plugins may not work correctly
 		updatetime = 200,
 		viewoptions = "folds,cursor,curdir,slash,unix",
 		virtualedit = "block",

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -20,6 +20,7 @@ completion["neovim/nvim-lspconfig"] = {
 	},
 }
 completion["hrsh7th/nvim-cmp"] = {
+	lazy = true,
 	event = "InsertEnter",
 	config = require("completion.cmp"),
 	dependencies = {
@@ -46,6 +47,7 @@ completion["hrsh7th/nvim-cmp"] = {
 	},
 }
 completion["zbirenbaum/copilot.lua"] = {
+	lazy = true,
 	cmd = "Copilot",
 	event = "InsertEnter",
 	config = require("completion.copilot"),

--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -12,7 +12,7 @@ editor["rmagatti/auto-session"] = {
 }
 editor["max397574/better-escape.nvim"] = {
 	lazy = true,
-	event = "BufReadPost",
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("editor.better-escape"),
 }
 editor["LunarVim/bigfile.nvim"] = {
@@ -26,12 +26,12 @@ editor["ojroques/nvim-bufdel"] = {
 }
 editor["rhysd/clever-f.vim"] = {
 	lazy = true,
-	event = "BufReadPost",
+	event = { "BufReadPost", "BufAdd", "BufNewFile" },
 	config = require("editor.cleverf"),
 }
 editor["numToStr/Comment.nvim"] = {
 	lazy = true,
-	event = { "BufNewFile", "BufReadPre" },
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("editor.comment"),
 }
 editor["sindrets/diffview.nvim"] = {
@@ -50,7 +50,7 @@ editor["phaazon/hop.nvim"] = {
 }
 editor["RRethy/vim-illuminate"] = {
 	lazy = true,
-	event = "BufReadPost",
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("editor.vim-illuminate"),
 }
 editor["luukvbaal/stabilize.nvim"] = {
@@ -68,7 +68,7 @@ editor["romainl/vim-cool"] = {
 editor["nvim-treesitter/nvim-treesitter"] = {
 	lazy = true,
 	build = ":TSUpdate",
-	event = "BufReadPost",
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("editor.treesitter"),
 	dependencies = {
 		{ "nvim-treesitter/nvim-treesitter-textobjects" },

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -6,7 +6,8 @@ tool["tpope/vim-fugitive"] = {
 }
 -- Please don't remove which-key.nvim otherwise you need to set timeoutlen=300 at `lua/core/options.lua`
 tool["folke/which-key.nvim"] = {
-	event = "VeryLazy",
+	lazy = true,
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("tool.which-key"),
 }
 -- only for fcitx5 user who uses non-English language during coding
@@ -41,7 +42,14 @@ tool["michaelb/sniprun"] = {
 }
 tool["akinsho/toggleterm.nvim"] = {
 	lazy = true,
-	event = "UIEnter",
+	cmd = {
+		"ToggleTerm",
+		"ToggleTermSetName",
+		"ToggleTermToggleAll",
+		"ToggleTermSendVisualLines",
+		"ToggleTermSendCurrentLine",
+		"ToggleTermSendVisualSelection",
+	},
 	config = require("tool.toggleterm"),
 }
 tool["folke/trouble.nvim"] = {

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -7,7 +7,7 @@ tool["tpope/vim-fugitive"] = {
 -- Please don't remove which-key.nvim otherwise you need to set timeoutlen=300 at `lua/core/options.lua`
 tool["folke/which-key.nvim"] = {
 	lazy = true,
-	event = { "CursorHold", "CursorHoldI" },
+	event = "VeryLazy",
 	config = require("tool.which-key"),
 }
 -- only for fcitx5 user who uses non-English language during coding

--- a/lua/modules/plugins/ui.lua
+++ b/lua/modules/plugins/ui.lua
@@ -26,7 +26,7 @@ ui["j-hui/fidget.nvim"] = {
 }
 ui["lewis6991/gitsigns.nvim"] = {
 	lazy = true,
-	event = { "BufReadPost", "BufNewFile" },
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("ui.gitsigns"),
 }
 ui["lukas-reineke/indent-blankline.nvim"] = {


### PR DESCRIPTION
As mentioned in #501.

### ❗❗ The most obvious defect is this commit will cause external measuring tools to calculate the startup time incorrectly _(the delay of 200ms set by `updatetime` while loading is still within the acceptable range)_.

However, the "user-perceived" startup time _(especially in the case of directly opening a file for editing)_ will be **_greatly_** reduced (Tested on macOS)

@CharlesChiuGit Can you help me double-check whether there're feature breakages?