### PR TITLE
chore(ci): disable updating lazy-lock when push commits

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -2,10 +2,6 @@ name: update lockfile
 on:
   # Scheduled update (each day)
   schedule: [{ cron: "30 01 * * *" }]
-  workflow_dispatch:
-  push:
-    branches:
-      - "main"
 
 jobs:
   update-lockfile:


### PR DESCRIPTION
IMO, we don't need the bot to run on per-commit base. 
It's just a wast of computing resources, also it failed sometimes weirdly which is annoying.