### PR TITLE
fix: `keymap.helpers` must be required first

### DIFF
--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -3,6 +3,7 @@ local map_cr = bind.map_cr
 local map_cu = bind.map_cu
 local map_cmd = bind.map_cmd
 local map_callback = bind.map_callback
+require("keymap.helpers")
 
 local plug_map = {
 	-- Plugin: vim-fugitive


### PR DESCRIPTION
Otherwise, `_toggle_lazygit()` or `_command_panel()` won't work.