### PR TITLE
perf: only attach lualine on LSP setup

### DIFF
--- a/lua/modules/plugins/ui.lua
+++ b/lua/modules/plugins/ui.lua
@@ -36,7 +36,7 @@ ui["lukas-reineke/indent-blankline.nvim"] = {
 }
 ui["nvim-lualine/lualine.nvim"] = {
 	lazy = true,
-	event = { "BufReadPost", "BufAdd", "BufNewFile" },
+	event = "LspAttach",
 	config = require("ui.lualine"),
 }
 ui["zbirenbaum/neodim"] = {


### PR DESCRIPTION
Note that we are using lspsaga with lualine. This means it will be a bit more
expensive to load lspsaga with BufReadPost. We probably only need to use lualine
once LspAttach is called.

This makes it around 10ms faster startup time.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
