### PR TITLE
fix: remove autocompletion on dap-repl

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -120,7 +120,6 @@ function autocmd.load_autocmds()
 			{ "FileType", "alpha", "set showtabline=0" },
 			{ "FileType", "markdown", "set wrap" },
 			{ "FileType", "make", "set noexpandtab shiftwidth=8 softtabstop=0" },
-			{ "FileType", "dap-repl", "lua require('dap.ext.autocompl').attach()" },
 			{
 				"FileType",
 				"*",


### PR DESCRIPTION
This PR address an issue when after exiting the dap-repl buffer,
it mess up with the current completion system.

This has to do with us not using omni completion (which dap-repl.ext.autocmpl relies on).

Might be a good idea to write our own completion system for dap-repl if needed.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
