### PR TITLE
feat(dap-dlv): add args support

### DIFF
--- a/lua/modules/configs/tool/dap/dap-dlv.lua
+++ b/lua/modules/configs/tool/dap/dap-dlv.lua
@@ -40,6 +40,21 @@ dap.configurations.go = {
 	{ type = "go", name = "Debug", request = "launch", program = "${file}" },
 	{
 		type = "go",
+		name = "Debug with args",
+		request = "launch",
+		program = "${file}",
+		args = function()
+			local args = {}
+			local args_string = vim.fn.input("Args: ")
+			for word in args_string:gmatch("%S+") do
+				table.insert(args, word)
+			end
+			vim.notify(args)
+			return args
+		end,
+	},
+	{
+		type = "go",
 		name = "Debug test", -- configuration for debugging test files
 		request = "launch",
 		mode = "test",


### PR DESCRIPTION
Sometimes we need to debug programe with args, and now dap-dlv is missing a debugger that supports input args.

According to [nvim-dap#620](https://github.com/mfussenegger/nvim-dap/issues/629), we can input args dynamically by `vim.fn.input`.

This is well tested in my mahine with the latest dap.nvim.