### PR TITLE
feat(ci): update lockfile only when there are new commits

### DIFF
--- a/.github/workflows/update_lockfile.yml
+++ b/.github/workflows/update_lockfile.yml
@@ -11,22 +11,28 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
       - uses: andstor/file-existence-action@v2
         id: check_lockfile
         with:
           files: "lazy-lock.json"
+      - name: Run count-new-commits
+        run: |
+          echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' --perl-regexp --author='^((?!github-actions).*)$' | wc -l)" >> "$GITHUB_ENV"
       - uses: rhysd/action-setup-vim@v1
+        if: ${{ steps.check_lockfile.outputs.files_exists == 'true' && env.NEW_COMMIT_COUNT > 0 }}
         with:
           neovim: true
       - name: Run lockfile-autoupdate
-        if: steps.check_lockfile.outputs.files_exists == 'true'
+        if: ${{ steps.check_lockfile.outputs.files_exists == 'true' && env.NEW_COMMIT_COUNT > 0 }}
         timeout-minutes: 5
         run: |
           ./scripts/install.sh
           nvim --headless "+Lazy! update" +qa
           cp -pv "${HOME}/.config/nvim/lazy-lock.json" .
-      - if: steps.check_lockfile.outputs.files_exists == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ steps.check_lockfile.outputs.files_exists == 'true' && env.NEW_COMMIT_COUNT > 0 }}
         with:
           commit_message: "chore(lockfile): auto update lazy-lock.json"
           commit_user_name: "github-actions[bot]"


### PR DESCRIPTION
This PR would stop `update_lockfile.yml` from messing up the commit history.