### PR TITLE
fix: disable luasnip jumps if the cursor isn't inside a snippet

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -96,7 +96,7 @@ return function()
 			["<Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_next_item()
-				elseif require("luasnip").expand_or_jumpable() then
+				elseif require("luasnip").expand_or_locally_jumpable() then
 					vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"), "")
 				else
 					fallback()


### PR DESCRIPTION
This PR should resolve #588.

From the documentation:
- `expand_or_locally_jumpable()`: same as `expand_or_jumpable()` **except jumpable is ignored if the cursor is not inside the current snippet**.