### PR TITLE
pref(cmp)!: update keymap for `cmp.close`

### DIFF
--- a/dots.tutor
+++ b/dots.tutor
@@ -105,7 +105,7 @@ The completion window will always show no matter what file you are editing.
 You can use `<Tab>`{normal} and `<S-Tab>`{normal} to select next and previous candidate in
 the completion window and use `<CR>`{normal} to confirm completion. You can also use
 `<C-n>`{normal} and `<C-p>`{normal} and `<C-y>`{normal} to do it. Sometimes you don't want confirm
-completion but just want to new a line, you can use `<C-e>`{normal} to close the
+completion but just want to new a line, you can use `<C-w>`{normal} to close the
 window manually.
 
 There are more functions provided by lsp besides code completion.

--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -92,7 +92,7 @@ return function()
 			["<C-n>"] = cmp.mapping.select_next_item(),
 			["<C-d>"] = cmp.mapping.scroll_docs(-4),
 			["<C-f>"] = cmp.mapping.scroll_docs(4),
-			["<C-e>"] = cmp.mapping.close(),
+			["<C-w>"] = cmp.mapping.close(),
 			["<Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_next_item()


### PR DESCRIPTION
This commit changes the keymap for `cmp.close` from `<C-e>` to `<C-w>`.

This way:
* Makes the keymap more intuitive and easier to memorize (`<C-w>` --> Close the focused window on most platforms)
* Makes `cmp.close` easier to type _(`w` is closer to `<CTRL>` than `e`)_

As this change does not conflict with `<C-w>` in normal mode, no conflicting keymap was found for the time being.