### PR TITLE
perf(icon): add cmp icons for `codeium` and `tabnine`

### DIFF
--- a/lua/modules/utils/icons.lua
+++ b/lua/modules/utils/icons.lua
@@ -160,8 +160,8 @@ local data = {
 		Vim = "",
 	},
 	cmp = {
-		Codeium = "",
-		TabNine = "",
+		Codeium = "",
+		TabNine = "",
 		Copilot = "",
 		Copilot_alt = "",
 		nvim_lsp = "",


### PR DESCRIPTION
Without these icons, `cmp` will throw errors when showing suggestion windows.
No very creative tho lol