### PR TITLE
feat(lspsaga): support v0.2.9

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -38,6 +38,11 @@ settings["colorscheme"] = "catppuccin"
 ---@type "dark"|"light"
 settings["background"] = "dark"
 
+-- Set the command for handling external URLs here. The executable must be available on your $PATH.
+-- This entry is IGNORED on Windows and macOS, which have their default handlers builtin.
+---@type string
+settings["external_browser"] = "chrome-cli open"
+
 -- Filetypes in this list will skip lsp formatting if rhs is true
 ---@type table<string, boolean>
 settings["formatter_block_list"] = {

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -11,14 +11,10 @@ local plug_map = {
 	["n|go"] = map_cr("Lspsaga outline"):with_noremap():with_silent():with_desc("lsp: Toggle outline"),
 	["n|g["] = map_cr("Lspsaga diagnostic_jump_prev"):with_noremap():with_silent():with_desc("lsp: Prev diagnostic"),
 	["n|g]"] = map_cr("Lspsaga diagnostic_jump_next"):with_noremap():with_silent():with_desc("lsp: Next diagnostic"),
-	["n|<leader>sl"] = map_cr("Lspsaga show_line_diagnostics")
+	["n|<leader>ld"] = map_cr("Lspsaga show_line_diagnostics")
 		:with_noremap()
 		:with_silent()
 		:with_desc("lsp: Line diagnostic"),
-	["n|<leader>sc"] = map_cr("Lspsaga show_cursor_diagnostics")
-		:with_noremap()
-		:with_silent()
-		:with_desc("lsp: Cursor diagnostic"),
 	["n|gs"] = map_callback(function()
 			vim.lsp.buf.signature_help()
 		end)

--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -93,7 +93,7 @@ return function()
 		},
 		hover = {
 			open_link = "gl",
-			open_browser = "!chrome",
+			open_browser = "silent !" .. require("core.settings").external_browser,
 		},
 		outline = {
 			win_position = "right",

--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -38,7 +38,7 @@ return function()
 		finder = {
 			keys = {
 				jump_to = "e",
-				edit = { "o", "<CR>" },
+				expand_or_jump = "<CR>",
 				vsplit = "s",
 				split = "i",
 				tabe = "t",
@@ -68,17 +68,20 @@ return function()
 			virtual_text = false,
 		},
 		diagnostic = {
+			text_hl_follow = true,
 			on_insert = true,
 			on_insert_follow = false,
 			show_code_action = true,
-			show_virt_line = true,
 			show_source = true,
 			border_follow = true,
+			extend_relatedInformation = false,
 			jump_num_shortcut = true,
 			keys = {
-				exec_action = "<CR>",
+				exec_action = "r",
 				quit = "q",
 				go_action = "g",
+				expand_or_jump = "<CR>",
+				quit_in_show = { "q", "<ESC>" },
 			},
 		},
 		rename = {
@@ -88,6 +91,10 @@ return function()
 			exec = "<CR>",
 			in_select = true,
 		},
+		hover = {
+			open_link = "gl",
+			open_browser = "!chrome",
+		},
 		outline = {
 			win_position = "right",
 			win_with = "_sagaoutline",
@@ -96,8 +103,7 @@ return function()
 			auto_refresh = true,
 			auto_close = true,
 			keys = {
-				jump = "<CR>",
-				expand_collapse = "u",
+				expand_or_jump = "<CR>",
 				quit = "q",
 			},
 		},
@@ -115,12 +121,12 @@ return function()
 		ui = {
 			border = "single", -- Can be single, double, rounded, solid, shadow.
 			winblend = 0,
+			actionfix = icons.ui.Spell,
 			expand = icons.ui.ArrowClosed,
 			collapse = icons.ui.ArrowOpen,
 			code_action = icons.ui.CodeAction,
 			incoming = icons.ui.Incoming,
 			outgoing = icons.ui.Outgoing,
-			diagnostic = " " .. icons.cmp.nvim_lsp,
 			kind = {
 				-- Kind
 				Class = { icons.kind.Class, "LspKindClass" },


### PR DESCRIPTION
This commit added support for lspsaga v0.2.9. Changes include:
* keymap for `show_line_diagnostics` was changed to `<leader>ld` (previously `<leader>sl`)
* `show_cursor_diagnostics` is deprecated - `<leader>sc` is now unset
* finder: option `edit` --> `expand_or_jump`
* diagnostic:
  * new options: `text_hl_follow`, `extend_relatedInformation`, `keys.*`
* hover: `open_link`, default to `gl`
* outline: All options are merged to give `expand_or_jump`
* ui:
  * removed entry: `diagnostic`
  * added entry: `actionfix` (`ui.Spell`)