### PR TITLE
feat: multimode keymap

### DIFF
--- a/lua/keymap/bind.lua
+++ b/lua/keymap/bind.lua
@@ -150,15 +150,17 @@ end
 ---@param mapping table<string, map_rhs>
 function bind.nvim_load_mapping(mapping)
 	for key, value in pairs(mapping) do
-		local mode, keymap = key:match("([^|]*)|?(.*)")
+		local modes, keymap = key:match("([^|]*)|?(.*)")
 		if type(value) == "table" then
-			local rhs = value.cmd
-			local options = value.options
-			local buf = value.buffer
-			if buf and type(buf) == "number" then
-				vim.api.nvim_buf_set_keymap(buf, mode, keymap, rhs, options)
-			else
-				vim.api.nvim_set_keymap(mode, keymap, rhs, options)
+			for _, mode in ipairs(vim.split(modes, "")) do
+				local rhs = value.cmd
+				local options = value.options
+				local buf = value.buffer
+				if buf and type(buf) == "number" then
+					vim.api.nvim_buf_set_keymap(buf, mode, keymap, rhs, options)
+				else
+					vim.api.nvim_set_keymap(mode, keymap, rhs, options)
+				end
 			end
 		end
 	end

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -27,8 +27,8 @@ local plug_map = {
 		:with_silent()
 		:with_desc("lsp: Rename in project range"),
 	["n|K"] = map_cr("Lspsaga hover_doc"):with_noremap():with_silent():with_desc("lsp: Show doc"),
-	["n|ga"] = map_cr("Lspsaga code_action"):with_noremap():with_silent():with_desc("lsp: Code action for cursor"),
-	["v|ga"] = map_cu("Lspsaga code_action"):with_noremap():with_silent():with_desc("lsp: Code action for range"),
+	["nv|ga"] = map_cr("Lspsaga code_action"):with_noremap():with_silent():with_desc("lsp: Code action for cursor"),
+	-- ["v|ga"] = map_cu("Lspsaga code_action"):with_noremap():with_silent():with_desc("lsp: Code action for range"),
 	["n|gd"] = map_cr("Lspsaga peek_definition"):with_noremap():with_silent():with_desc("lsp: Preview definition"),
 	["n|gD"] = map_cr("Lspsaga goto_definition"):with_noremap():with_silent():with_desc("lsp: Goto definition"),
 	["n|gh"] = map_cr("Lspsaga lsp_finder"):with_noremap():with_silent():with_desc("lsp: Show reference"),

--- a/lua/keymap/editor.lua
+++ b/lua/keymap/editor.lua
@@ -69,12 +69,7 @@ local plug_map = {
 	["n|<leader><leader>D"] = map_cr("DiffviewClose"):with_silent():with_noremap():with_desc("git: Close diff"),
 
 	-- Plugin: vim-easy-align
-	["n|gea"] = map_callback(function()
-			return et("<Plug>(EasyAlign)")
-		end)
-		:with_expr()
-		:with_desc("edit: Align with delimiter"),
-	["x|gea"] = map_callback(function()
+	["nx|gea"] = map_callback(function()
 			return et("<Plug>(EasyAlign)")
 		end)
 		:with_expr()

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -68,13 +68,7 @@ local plug_map = {
 		:with_silent()
 		:with_desc("terminal: Toggle float"),
 	["t|<A-d>"] = map_cmd("<Esc><Cmd>ToggleTerm<CR>"):with_noremap():with_silent():with_desc("terminal: Toggle float"),
-	["n|<leader>g"] = map_callback(function()
-			_toggle_lazygit()
-		end)
-		:with_noremap()
-		:with_silent()
-		:with_desc("git: Toggle lazygit"),
-	["t|<leader>g"] = map_callback(function()
+	["nt|<leader>g"] = map_callback(function()
 			_toggle_lazygit()
 		end)
 		:with_noremap()


### PR DESCRIPTION


I'm in the process of migrating my Neovim configuration and I have many nomode keymaps in VimL like:

```
noremap J=5j
```

This applies the keymap in "n", "v", and "o" modes. To achieve the same effect in `bind.nvim_load_mapping`, I currently have to write:

```
["n|J"] = map_cmd("5j"):with_silent():with_noremap():with_desc("long j"),
["v|J"] = map_cmd("5j"):with_silent():with_noremap():with_desc("long j"),
["o|J"] = map_cmd("5j"):with_silent():with_noremap():with_desc("long j"),
```

This appears to be very cumbersome and unnecessary. Therefore, I created this PR so we can write:

```
["nvo|J"] = map_cmd("5j"):with_silent():with_noremap():with_desc("long k"),
```

Please review this PR and let me know your thoughts.

