### PR TITLE
fix: easyalign keymap

### DIFF
--- a/lua/keymap/editor.lua
+++ b/lua/keymap/editor.lua
@@ -69,11 +69,7 @@ local plug_map = {
 	["n|<leader><leader>D"] = map_cr("DiffviewClose"):with_silent():with_noremap():with_desc("git: Close diff"),
 
 	-- Plugin: vim-easy-align
-	["nx|gea"] = map_callback(function()
-			return et("<Plug>(EasyAlign)")
-		end)
-		:with_expr()
-		:with_desc("edit: Align with delimiter"),
+	["nx|gea"] = map_cr("EasyAlign"):with_desc("edit: Align with delimiter"),
 
 	-- Plugin: hop
 	["n|<leader>w"] = map_cu("HopWord"):with_noremap():with_desc("jump: Goto word"),


### PR DESCRIPTION
The original easyalign keymap use `<Plug>(EasyAlign)` , which will not correctly hook lazyloading of easyalign as that's not actually us cmd `EasyAlign`
https://github.com/ayamir/nvimdots/blob/c56cd604dc3b9f7149b89f245206daf0b00b369c/lua/modules/plugins/editor.lua#L48