### PR TITLE
fix(cmp): handle LuaSnip jump failures

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -21,6 +21,17 @@ return function()
 		}
 	end
 
+	---Handling situations where LuaSnip failed to perform any jumps
+	---@param r integer @Cursor position (row) before calling LuaSnip
+	---@param c integer @Cursor position (col) before calling LuaSnip
+	---@param fallback function @Fallback function inherited from cmp
+	local luasnip_fallback = vim.schedule_wrap(function(r, c, fallback)
+		local _r, _c = unpack(vim.api.nvim_win_get_cursor(0))
+		if _r == r and _c == c then
+			fallback()
+		end
+	end)
+
 	local cmp_window = require("cmp.utils.window")
 
 	cmp_window.info_ = cmp_window.info
@@ -97,7 +108,9 @@ return function()
 				if cmp.visible() then
 					cmp.select_next_item()
 				elseif require("luasnip").expand_or_locally_jumpable() then
-					vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"), "")
+					local _r, _c = unpack(vim.api.nvim_win_get_cursor(0))
+					vim.fn.feedkeys(t("<Plug>luasnip-expand-or-jump"))
+					luasnip_fallback(_r, _c, fallback)
 				else
 					fallback()
 				end


### PR DESCRIPTION
This PR should finally address https://github.com/ayamir/nvimdots/discussions/599.

Looks like LuaSnip regards the situation of "cursor being inside a snippet but unable to jump forward" as `locally_jumpable`. This PR checks whether the jump was successful by determining cursor positions before and after calling LuaSnip.

Here, `vim.schedule_wrap` is used to avoid calling this function before `vim.fn.feedkeys` is evaluated _(`feedkeys()` does not block the main thread)_.