### PR TITLE
Remove `popup.nvim` from dependencies of `telescope.nvim`

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -63,7 +63,6 @@
   "nvim-web-devicons": { "branch": "master", "commit": "0568104bf8d0c3ab16395433fcc5c1638efc25d4" },
   "paint.nvim": { "branch": "main", "commit": "6ce64212804f425073c61ab0d9c2b034f0435260" },
   "plenary.nvim": { "branch": "master", "commit": "253d34830709d690f013daf2853a9d21ad7accab" },
-  "popup.nvim": { "branch": "master", "commit": "b7404d35d5d3548a82149238289fa71f7f6de4ac" },
   "project.nvim": { "branch": "main", "commit": "1c2e9c93c7c85126c2197f5e770054f53b1926fb" },
   "rust-tools.nvim": { "branch": "master", "commit": "71d2cf67b5ed120a0e31b2c8adb210dd2834242f" },
   "smartyank.nvim": { "branch": "master", "commit": "7e3905578f646503525b2f7018b8afd17861018c" },

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -75,7 +75,6 @@ tool["nvim-telescope/telescope.nvim"] = {
 	dependencies = {
 		{ "nvim-tree/nvim-web-devicons" },
 		{ "nvim-lua/plenary.nvim" },
-		{ "nvim-lua/popup.nvim" },
 		{ "debugloop/telescope-undo.nvim" },
 		{
 			"ahmedkhalf/project.nvim",


### PR DESCRIPTION
`popup.nvim` is merged into `plenary.nvim`. See [plenary.nvim repository, PR209](https://github.com/nvim-lua/plenary.nvim/pull/209).  
`telescope.nvim` nolonger depends on that package.