### PR TITLE
feat!: add initial support for lsp semantic tokens

### DIFF
--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -120,6 +120,7 @@ return function()
 			frequency = 12,
 		},
 		ui = {
+			title = false,
 			border = "single", -- Can be single, double, rounded, solid, shadow.
 			winblend = 0,
 			actionfix = icons.ui.Spell,

--- a/lua/modules/configs/ui/catppuccin.lua
+++ b/lua/modules/configs/ui/catppuccin.lua
@@ -77,7 +77,7 @@ return function()
 			nvimtree = true,
 			overseer = false,
 			pounce = false,
-			semantic_tokens = false,
+			semantic_tokens = true,
 			symbols_outline = false,
 			telekasten = false,
 			telescope = true,
@@ -149,6 +149,17 @@ return function()
 
 					-- For trouble.nvim
 					TroubleNormal = { bg = cp.base },
+
+					-- For lsp semantic tokens
+					["@lsp.type.comment"] = { fg = cp.overlay0 },
+					["@lsp.type.enum"] = { link = "@type" },
+					["@lsp.type.property"] = { link = "@property" },
+					["@lsp.type.macro"] = { link = "@constant" },
+					["@lsp.typemod.function.defaultLibrary"] = { fg = cp.blue, style = { "bold", "italic" } },
+					["@lsp.typemod.function.defaultLibrary.c"] = { fg = cp.blue, style = { "bold" } },
+					["@lsp.typemod.function.defaultLibrary.cpp"] = { fg = cp.blue, style = { "bold" } },
+					["@lsp.typemod.method.defaultLibrary"] = { link = "@lsp.typemod.function.defaultLibrary" },
+					["@lsp.typemod.variable.defaultLibrary"] = { fg = cp.flamingo },
 
 					-- For treesitter.
 					["@field"] = { fg = cp.rosewater },


### PR DESCRIPTION
This PR added initial support for lsp semantic tokens. It only implements **a small part** of semantic tokens.

Further development would require testing on more supported languages.