### PR TITLE
feat(alpha): add custom highlight groups

### DIFF
--- a/lua/modules/configs/ui/alpha.lua
+++ b/lua/modules/configs/ui/alpha.lua
@@ -35,7 +35,7 @@ return function()
 			cursor = 5,
 			width = 50,
 			align_shortcut = "right",
-			hl = "AlphaOptions",
+			hl = "AlphaButton",
 			hl_shortcut = "AlphaAttr",
 		}
 
@@ -118,7 +118,7 @@ return function()
 			end,
 		}),
 	}
-	dashboard.section.buttons.opts.hl = "AlphaOptions"
+	dashboard.section.buttons.opts.hl = "AlphaButton"
 
 	local function footer()
 		local stats = require("lazy").stats()

--- a/lua/modules/configs/ui/alpha.lua
+++ b/lua/modules/configs/ui/alpha.lua
@@ -1,6 +1,7 @@
 return function()
 	local alpha = require("alpha")
 	local dashboard = require("alpha.themes.dashboard")
+	require("modules.utils").gen_alpha_hl()
 
 	dashboard.section.header.val = {
 		[[⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]],
@@ -23,7 +24,7 @@ return function()
 		[[⠿⠛⠛⠛⠛⠛⠛⠻⢿⣿⣿⣿⣿⣯⣟⠷⢷⣿⡿⠋⠀⠀⠀⠀⣵⡀⢠⡿⠋⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]],
 		[[⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠛⢿⣿⣿⠂⠀⠀⠀⠀⠀⢀⣽⣿⣿⣿⣿⣿⣿⣿⣍⠛⠿⣿⣿⣿⣿⣿⣿]],
 	}
-	dashboard.section.header.opts.hl = "Type"
+	dashboard.section.header.opts.hl = "AlphaHeader"
 
 	local function button(sc, txt, leader_txt, keybind, keybind_opts)
 		local sc_after = sc:gsub("%s", ""):gsub(leader_txt, "<leader>")
@@ -34,7 +35,8 @@ return function()
 			cursor = 5,
 			width = 50,
 			align_shortcut = "right",
-			hl_shortcut = "Keyword",
+			hl = "AlphaOptions",
+			hl_shortcut = "AlphaAttr",
 		}
 
 		if nil == keybind then
@@ -116,7 +118,7 @@ return function()
 			end,
 		}),
 	}
-	dashboard.section.buttons.opts.hl = "String"
+	dashboard.section.buttons.opts.hl = "AlphaOptions"
 
 	local function footer()
 		local stats = require("lazy").stats()
@@ -136,7 +138,7 @@ return function()
 	end
 
 	dashboard.section.footer.val = footer()
-	dashboard.section.footer.opts.hl = "Function"
+	dashboard.section.footer.opts.hl = "AlphaFooter"
 
 	local head_butt_padding = 2
 	local occu_height = #dashboard.section.header.val + 2 * #dashboard.section.buttons.val + head_butt_padding

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -145,6 +145,7 @@ function M.get_palette(overwrite)
 	end
 end
 
+-- Generate highlight groups for lspsaga. Existing attributes will NOT be overwritten
 function M.gen_lspkind_hl()
 	local colors = M.get_palette()
 	local dat = {
@@ -187,6 +188,16 @@ function M.gen_lspkind_hl()
 	for kind, color in pairs(dat) do
 		vim.api.nvim_set_hl(0, "LspKind" .. kind, { fg = color, default = true })
 	end
+end
+
+-- Generate highlight groups for alpha. Existing attributes will NOT be overwritten
+function M.gen_alpha_hl()
+	local colors = M.get_palette()
+
+	vim.api.nvim_set_hl(0, "AlphaHeader", { fg = colors.blue, default = true })
+	vim.api.nvim_set_hl(0, "AlphaOptions", { fg = colors.green, default = true })
+	vim.api.nvim_set_hl(0, "AlphaAttr", { fg = colors.pink, italic = true, default = true })
+	vim.api.nvim_set_hl(0, "AlphaFooter", { fg = colors.yellow, default = true })
 end
 
 ---Convert number (0/1) to boolean

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -195,7 +195,7 @@ function M.gen_alpha_hl()
 	local colors = M.get_palette()
 
 	vim.api.nvim_set_hl(0, "AlphaHeader", { fg = colors.blue, default = true })
-	vim.api.nvim_set_hl(0, "AlphaOptions", { fg = colors.green, default = true })
+	vim.api.nvim_set_hl(0, "AlphaButton", { fg = colors.green, default = true })
 	vim.api.nvim_set_hl(0, "AlphaAttr", { fg = colors.pink, italic = true, default = true })
 	vim.api.nvim_set_hl(0, "AlphaFooter", { fg = colors.yellow, default = true })
 end


### PR DESCRIPTION
This PR prepares for [**! Refactor Treesitter highlights**](https://github.com/ayamir/nvimdots/issues/627). It separates the highlights for Alpha from those syntax-based highlights.