### PR TITLE
feat(nvim-tree): remove deprecated options

### DIFF
--- a/lua/modules/configs/tool/nvim-tree.lua
+++ b/lua/modules/configs/tool/nvim-tree.lua
@@ -13,9 +13,6 @@ return function()
 		hijack_cursor = true,
 		hijack_netrw = true,
 		hijack_unnamed_buffer_when_opening = true,
-		ignore_buffer_on_setup = false,
-		open_on_setup = false,
-		open_on_setup_file = false,
 		open_on_tab = false,
 		respect_buf_cwd = false,
 		sort_by = "name",
@@ -108,7 +105,6 @@ return function()
 			update_root = true,
 			ignore_list = {},
 		},
-		ignore_ft_on_setup = {},
 		filters = {
 			dotfiles = false,
 			custom = { ".DS_Store" },


### PR DESCRIPTION
open_on_setup mechanisms has been deprecated by [nvim-tree.lua#2122](https://github.com/nvim-tree/nvim-tree.lua/commit/48d53a5934fbd51b655d03db7dad35551838f2c9).

I received warning message after upgrading nvim-tree:

```
[NvimTree] unknown option: ignore_ft_on_setup | [NvimTree] unknown option: ignore_buffer_on_setup | [NvimTree] unknown option: open_on_setup | [NvimTree] unknown option: open_on_setup_file | see :help nvim-tree-setup for available configuration options
```

These options should be removed.