### PR TITLE
fix(font-encoding): fix invalid characters on windows, fix #639

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -132,11 +132,11 @@ You're recommended to install Windows PowerShell for better experience.]],
 			return
 		end
 
-		local basecmd = "-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned "
+		local basecmd = "-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned"
 		local ctrlcmd =
 			"-Command $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding"
 		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})
-		vim.api.nvim_set_option_value("shellcmdflag", basecmd .. ctrlcmd .. ";", {})
+		vim.api.nvim_set_option_value("shellcmdflag", string.format("%s %s;", basecmd, ctrlcmd), {})
 		vim.api.nvim_set_option_value("shellredir", '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode', {})
 		vim.api.nvim_set_option_value("shellpipe", '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode', {})
 		vim.api.nvim_set_option_value("shellquote", nil, {})

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -115,6 +115,18 @@ local clipboard_config = function()
 	end
 end
 
+local win_shell_config = function()
+	if global.is_windows then
+		vim.o.shell = "powershell.exe"
+		vim.o.shellcmdflag =
+			"-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues['Out-File:Encoding']='utf-8';"
+		vim.o.shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+		vim.o.shellpipe = '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode'
+		vim.o.shellquote = ""
+		vim.o.shellxquote = ""
+	end
+end
+
 local load_core = function()
 	createdir()
 	disable_distribution_plugins()
@@ -122,6 +134,7 @@ local load_core = function()
 
 	neovide_config()
 	clipboard_config()
+	win_shell_config()
 
 	require("core.options")
 	require("core.mapping")

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -123,16 +123,16 @@ local shell_config = function()
 Failed to setup terminal config
 
 PowerShell is either not installed, missing from PATH, or not executable;
-cmd.exe will be used instead for `:!` (shell bang).
+cmd.exe will be used instead for `:!` (shell bang) and toggleterm.nvim.
 
-You're recommended to install Windows PowerShell for better experience.]],
+You're recommended to install PowerShell for better experience.]],
 				vim.log.levels.WARN,
 				{ title = "[core] Runtime error" }
 			)
 			return
 		end
 
-		local basecmd = "-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned"
+		local basecmd = "-NoLogo -NoExit -ExecutionPolicy RemoteSigned"
 		local ctrlcmd =
 			"-Command $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding"
 		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -115,15 +115,32 @@ local clipboard_config = function()
 	end
 end
 
-local win_shell_config = function()
+local shell_config = function()
 	if global.is_windows then
-		vim.o.shell = vim.fn.executable("pwsh") and "pwsh" or "powershell"
-		vim.o.shellcmdflag =
-			"-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues['Out-File:Encoding']='utf-8';"
-		vim.o.shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-		vim.o.shellpipe = '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode'
-		vim.o.shellquote = ""
-		vim.o.shellxquote = ""
+		if not (vim.fn.executable("pwsh") or vim.fn.executable("powershell")) then
+			vim.notify(
+				[[
+Failed to setup terminal config
+
+PowerShell is either not installed, missing from PATH, or not executable;
+cmd.exe will be used instead for `:!` (shell bang).
+
+You're recommended to install Windows PowerShell for better experience.]],
+				vim.log.levels.WARN,
+				{ title = "[core] Runtime error" }
+			)
+			return
+		end
+
+		local basecmd = "-NoLogo -NonInteractive -ExecutionPolicy RemoteSigned "
+		local ctrlcmd =
+			"-Command $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding"
+		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})
+		vim.api.nvim_set_option_value("shellcmdflag", basecmd .. ctrlcmd .. ";", {})
+		vim.api.nvim_set_option_value("shellredir", '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode', {})
+		vim.api.nvim_set_option_value("shellpipe", '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode', {})
+		vim.api.nvim_set_option_value("shellquote", nil, {})
+		vim.api.nvim_set_option_value("shellxquote", nil, {})
 	end
 end
 
@@ -134,7 +151,7 @@ local load_core = function()
 
 	neovide_config()
 	clipboard_config()
-	win_shell_config()
+	shell_config()
 
 	require("core.options")
 	require("core.mapping")

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -132,7 +132,7 @@ You're recommended to install PowerShell for better experience.]],
 			return
 		end
 
-		local basecmd = "-NoLogo -MTA -NoLogo -NoProfileLoadTime -NonInteractive -ExecutionPolicy RemoteSigned"
+		local basecmd = "-NoLogo -MTA -NoProfileLoadTime -NonInteractive -ExecutionPolicy RemoteSigned"
 		local ctrlcmd = "-Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})
 		vim.api.nvim_set_option_value("shellcmdflag", string.format("%s %s;", basecmd, ctrlcmd), {})

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -132,9 +132,8 @@ You're recommended to install PowerShell for better experience.]],
 			return
 		end
 
-		local basecmd = "-NoLogo -NoExit -ExecutionPolicy RemoteSigned"
-		local ctrlcmd =
-			"-Command $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding"
+		local basecmd = "-NoLogo -MTA -NoLogo -NoProfileLoadTime -NonInteractive -ExecutionPolicy RemoteSigned"
+		local ctrlcmd = "-Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})
 		vim.api.nvim_set_option_value("shellcmdflag", string.format("%s %s;", basecmd, ctrlcmd), {})
 		vim.api.nvim_set_option_value("shellredir", '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode', {})

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -117,7 +117,7 @@ end
 
 local win_shell_config = function()
 	if global.is_windows then
-		vim.o.shell = "powershell.exe"
+		vim.o.shell = vim.fn.executable("pwsh") and "pwsh" or "powershell"
 		vim.o.shellcmdflag =
 			"-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues['Out-File:Encoding']='utf-8';"
 		vim.o.shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -132,12 +132,12 @@ You're recommended to install PowerShell for better experience.]],
 			return
 		end
 
-		local basecmd = "-NoLogo -MTA -NoProfileLoadTime -NonInteractive -ExecutionPolicy RemoteSigned"
+		local basecmd = "-NoLogo -MTA -ExecutionPolicy RemoteSigned"
 		local ctrlcmd = "-Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8"
 		vim.api.nvim_set_option_value("shell", vim.fn.executable("pwsh") and "pwsh" or "powershell", {})
 		vim.api.nvim_set_option_value("shellcmdflag", string.format("%s %s;", basecmd, ctrlcmd), {})
-		vim.api.nvim_set_option_value("shellredir", '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode', {})
-		vim.api.nvim_set_option_value("shellpipe", '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode', {})
+		vim.api.nvim_set_option_value("shellredir", "-RedirectStandardOutput %s -NoNewWindow -Wait", {})
+		vim.api.nvim_set_option_value("shellpipe", "2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode", {})
 		vim.api.nvim_set_option_value("shellquote", nil, {})
 		vim.api.nvim_set_option_value("shellxquote", nil, {})
 	end

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -125,7 +125,7 @@ local function load_options()
 	-- Fix sqlite3 missing-lib issue on Windows
 	if global.is_windows then
 		-- Download the DLLs form https://www.sqlite.org/download.html
-		vim.g.sqlite_clib_path = global.home .. "/Documents/sqlite-dll-win64-x64-3400100/sqlite3.dll"
+		vim.g.sqlite_clib_path = global.home .. "/Documents/sqlite-dll-win64-x64-3400200/sqlite3.dll"
 	end
 end
 


### PR DESCRIPTION
1. set default shell from `cmd` to `powershell`.[^1]
2. set `fileendoing` to use `utf-8` only

All screenshots are taken in windows terminal

TODO:
1. ~~icon overlapping~~ (if anyone have this issue, just try another nerdfont)
2. icon won't show in `toggleterm.nvim`, it only works in the neovim built-in terminal.
![圖片](https://user-images.githubusercontent.com/32497323/231940345-a0d0ea66-26eb-4bb7-8da6-e921e2779aff.png)

Results:
![圖片](https://user-images.githubusercontent.com/32497323/231939889-83a27da0-d714-46e9-a0a0-f8e87df646eb.png)
![圖片](https://user-images.githubusercontent.com/32497323/231939920-78afe24d-0701-4c73-b10c-7a2f78f27987.png)


[^1]: `pwsh` would be better, but it's not installed on windows by default. Only `cmd` and `powershell` are.