### PR TITLE
fix: error caused by treesitter entry_filter.

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -151,11 +151,15 @@ return function()
 			{
 				name = "treesitter",
 				entry_filter = function(entry)
+					local types = require("cmp.types")
+					local cmp_opts = entry:get_completion_item().cmp or {}
+					local kind = cmp_opts.kind_text
+						or types.lsp.CompletionItemKind[entry:get_kind()]
+						or types.lsp.CompletionItemKind[1]
 					local ignore_list = {
 						"Error",
 						"Comment",
 					}
-					local kind = entry:get_completion_item().cmp.kind_text
 					return not vim.tbl_contains(ignore_list, kind)
 				end,
 			},


### PR DESCRIPTION
I got error under current config, and I don't know why a `entry_filter` is needed for treesitter source.

![image](https://user-images.githubusercontent.com/61657399/232307203-689e6ea4-5d1b-4f5c-98c3-0b9a016c7c31.png)
