### PR TITLE
fix: paint word boundary in python

### DIFF
--- a/lua/modules/configs/ui/paint.lua
+++ b/lua/modules/configs/ui/paint.lua
@@ -12,7 +12,7 @@ return function()
 			},
 			{
 				filter = { filetype = "python" },
-				pattern = "%s*(%w+:)",
+				pattern = "%s*([_%w]+:)",
 				hl = "Constant",
 			},
 		},


### PR DESCRIPTION
Current paint setup falsely recognize word boundary in python
![image](https://user-images.githubusercontent.com/41792945/233018511-1126f895-ca13-40cc-a732-49fabcdd042e.png)
