### PR TITLE
fix(bufferline): use defaults for `get_element_icon`

### DIFF
--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -20,13 +20,6 @@ return function()
 			persist_buffer_sort = true,
 			always_show_bufferline = true,
 			separator_style = "thin",
-			get_element_icon = function(buf)
-				return require("nvim-web-devicons").get_icon(
-					buf.name,
-					vim.bo.filetype,
-					{ default = true, strict = true }
-				)
-			end,
 			diagnostics = "nvim_lsp",
 			diagnostics_indicator = function(count)
 				return "(" .. count .. ")"


### PR DESCRIPTION
This PR partially reverted commit ecaba008ae53e66113f0938a0605416de4d3ec83, fixing a regression.

Under current config _(using custom `get_element_icon`)_, all tabs will have the same icon _(since `vim.bo.filetype` can only hold one valid value)_