### PR TITLE
feat: make ui more tidy and unified

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -75,12 +75,14 @@ return function()
 	cmp.setup({
 		window = {
 			completion = {
-				border = border("Normal"),
+				border = border("PmenuBorder"),
+				winhighlight = "Normal:Pmenu,CursorLine:PmenuSel,Search:PmenuSel",
 				max_width = 80,
 				max_height = 20,
 			},
 			documentation = {
-				border = border("CmpDocBorder"),
+				border = border("PmenuBorder"),
+				winhighlight = "Normal:Pmenu",
 			},
 		},
 		sorting = {

--- a/lua/modules/configs/tool/wilder.lua
+++ b/lua/modules/configs/tool/wilder.lua
@@ -25,13 +25,12 @@ return function()
 		),
 	})
 
-	local match_hl = require("modules.utils").hl_to_rgb("String", false, colors.green)
-
 	local popupmenu_renderer = wilder.popupmenu_renderer(wilder.popupmenu_border_theme({
 		border = "rounded",
 		highlights = {
-			border = "Title", -- highlight to use for the border
-			accent = wilder.make_hl("WilderAccent", "Pmenu", { { a = 0 }, { a = 0 }, { foreground = match_hl } }),
+			default = "Pmenu",
+			border = "PmenuBorder", -- highlight to use for the border
+			accent = wilder.make_hl("WilderAccent", "CmpItemAbbr", "CmpItemAbbrMatch"),
 		},
 		empty_message = wilder.popupmenu_empty_message_with_spinner(),
 		highlighter = wilder.lua_fzy_highlighter(),

--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -24,18 +24,23 @@ return function()
 			diagnostics_indicator = function(count)
 				return "(" .. count .. ")"
 			end,
+			indicator = {
+				-- icon = "▎",
+				icon = " ",
+				style = "icon",
+			},
 			offsets = {
 				{
 					filetype = "NvimTree",
-					text = "File Explorer",
+					text = "",
 					text_align = "center",
-					padding = 1,
+					padding = 0,
 				},
 				{
 					filetype = "lspsagaoutline",
-					text = "Lspsaga Outline",
+					text = "",
 					text_align = "center",
-					padding = 1,
+					padding = 0,
 				},
 			},
 		},

--- a/lua/modules/configs/ui/catppuccin.lua
+++ b/lua/modules/configs/ui/catppuccin.lua
@@ -131,6 +131,24 @@ return function()
 					Type = { fg = cp.blue },
 					Typedef = { fg = cp.yellow },
 					StorageClass = { fg = cp.red, style = { "italic" } },
+					WinSeparator = { bg = cp.base, fg = cp.base },
+
+					-- For indent-blankline
+					IndentBlanklineContextChar = { fg = cp.pink },
+
+					-- For nvim-tree
+					NvimTreeIndentMarker = { fg = cp.surface0 },
+
+					-- For nvim-cmp and wilder
+					Pmenu = { fg = cp.overlay2, bg = transparent_background and cp.none or cp.base },
+					PmenuBorder = { fg = cp.surface1, bg = transparent_background and cp.none or cp.base },
+					PmenuSel = { bg = cp.green, fg = cp.base },
+					CmpItemAbbr = { fg = cp.overlay2 },
+					CmpItemAbbrMatch = { fg = cp.blue, style = { "bold" } },
+
+					-- For lspsaga
+					OutlineNormal = { bg = cp.crust },
+					OutlineIndent = { fg = cp.surface0 },
 
 					-- For native lsp configs.
 					DiagnosticVirtualTextError = { bg = cp.none },


### PR DESCRIPTION
1. same appearance for cmp and wilder
2. clear appearance for bufferline working with nvim-tree and outline (lspsaga)
3. colored indent-blankline
4. similar highlights for indent lines in nvim-tree, indent-blankline and outline (lspsaga)