### PR TITLE
fix(lsp): set default python lsp to `pylsp`, avoid high CPU load caused by `jedi`.

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -63,6 +63,7 @@ settings["server_formatting_block_list"] = {
 	lua_ls = true,
 	tsserver = true,
 	clangd = true,
+	pylsp = true,
 }
 
 -- Set the language servers that will be installed during bootstrap here
@@ -75,7 +76,7 @@ settings["lsp_deps"] = {
 	"html",
 	"jsonls",
 	"lua_ls",
-	"jedi_language_server",
+	"pylsp",
 	-- "gopls",
 }
 


### PR DESCRIPTION
#721