### PR TITLE
feat(cmp): enable `experimental.ghost_text`

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -168,5 +168,10 @@ return function()
 			-- { name = "codeium" },
 			-- { name = "cmp_tabnine" },
 		},
+		experimental = {
+			ghost_text = {
+				hl_group = "Whitespace",
+			},
+		},
 	})
 end


### PR DESCRIPTION
This should be the feature requested by the author @namespacebilibili in https://github.com/ayamir/nvimdots/discussions/623#discussion-5052353. I'm not sure if this is compatible with `copilot`.