### PR TITLE
feat(neodim): support v2

### DIFF
--- a/lua/modules/configs/ui/neodim.lua
+++ b/lua/modules/configs/ui/neodim.lua
@@ -4,14 +4,13 @@ return function()
 	require("neodim").setup({
 		alpha = 0.45,
 		blend_color = blend_color,
-		update_in_insert = {
-			enable = true,
-			delay = 100,
-		},
+		refresh_delay = 75, -- time in ms to wait after typing before refreshing diagnostics
 		hide = {
 			virtual_text = true,
 			signs = false,
 			underline = false,
 		},
+		priority = 80,
+		disable = { "big_file_disabled_ft" },
 	})
 end

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -110,9 +110,9 @@ function M.hl_to_rgb(hl_group, use_bg, fallback_hl)
 	if hlexists then
 		local result = vim.api.nvim_get_hl(0, { name = hl_group, link = false })
 		if use_bg then
-			hex = result.bg and result.bg or "NONE"
+			hex = result.bg and string.format("#%06x", result.bg) or "NONE"
 		else
-			hex = result.fg and result.fg or "NONE"
+			hex = result.fg and string.format("#%06x", result.fg) or "NONE"
 		end
 	end
 


### PR DESCRIPTION
I'm not sure why `nvim_get_hl` returns a decimal RGB value instead of a hex string.

@ayamir @CharlesChiuGit Have u encountered similar issues?
```lua
:=vim.api.nvim_get_hl(0, { name = "Normal" })
```
Returns
```console
{
  bg = 1973806,
  fg = 13489908
}
Press ENTER or type command to continue
```
But according to the documentation, it _should_ return:
```console
{
  bg = #1E1E2E,
  fg = #CDD6F4
}
Press ENTER or type command to continue
```