### PR TITLE
feat: set default config for pylsp.

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -67,7 +67,6 @@ settings["server_formatting_block_list"] = {
 	lua_ls = true,
 	tsserver = true,
 	clangd = true,
-	pylsp = true,
 }
 
 -- Set the language servers that will be installed during bootstrap here.
@@ -90,7 +89,6 @@ settings["lsp_deps"] = {
 -- https://github.com/jose-elias-alvarez/null-ls.nvim/tree/main/lua/null-ls/builtins
 ---@type string[]
 settings["null_ls_deps"] = {
-	"black",
 	"clang_format",
 	"prettier",
 	"rustfmt",

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -98,4 +98,42 @@ return function()
 		local final_opts = vim.tbl_deep_extend("keep", _opts, opts)
 		nvim_lsp.dartls.setup(final_opts)
 	end
+
+	local function mason_post_install(pkg)
+		if pkg.name ~= "python-lsp-server" then
+			return
+		end
+
+		local venv = vim.fn.stdpath("data") .. "/mason/packages/python-lsp-server/venv"
+		local job = require("plenary.job")
+
+		job:new({
+			command = venv .. "/bin/pip",
+			args = {
+				"install",
+				"-U",
+				"--disable-pip-version-check",
+				"python-lsp-black",
+				"python-lsp-ruff",
+				"pylsp-rope",
+				"pyls-isort",
+			},
+			cwd = venv,
+			env = { VIRTUAL_ENV = venv },
+			on_exit = function()
+				if vim.fn.executable(venv .. "/bin/black") == 1 and vim.fn.executable(venv .. "/bin/ruff") == 1 then
+					vim.notify("Finished installing pylsp plugins.")
+					return
+				end
+			end,
+			on_start = function()
+				vim.notify("Installing pylsp plugins...")
+			end,
+			on_stderr = function(_, data)
+				vim.notify(data, vim.log.levels.ERROR)
+			end,
+		}):start()
+	end
+
+	require("mason-registry"):on("package:install:success", mason_post_install)
 end

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -116,7 +116,6 @@ return function()
 				"python-lsp-black",
 				"python-lsp-ruff",
 				"pylsp-rope",
-				"pyls-isort",
 			},
 			cwd = venv,
 			env = { VIRTUAL_ENV = venv },

--- a/lua/modules/configs/completion/null-ls.lua
+++ b/lua/modules/configs/completion/null-ls.lua
@@ -6,9 +6,6 @@ return function()
 	-- Please set additional flags for the supported servers here
 	-- Don't specify any config here if you are using the default one.
 	local sources = {
-		btns.formatting.black.with({
-			extra_args = { "--fast" },
-		}),
 		btns.formatting.clang_format.with({
 			filetypes = { "c", "cpp" },
 			extra_args = require("completion.formatters.clang_format"),

--- a/lua/modules/configs/completion/servers/pylsp.lua
+++ b/lua/modules/configs/completion/servers/pylsp.lua
@@ -6,20 +6,33 @@ return {
 				-- lint related
 				ruff = {
 					enabled = true,
+					select = {
+						-- enable pycodestyle
+						"E",
+						-- enable pyflakes
+						"F",
+					},
+					ignore = {
+						-- ignore E501 (line too long)
+						"E501",
+						-- ignore F401 (imported but unused)
+						"F401",
+					},
 					extendSelect = { "I" },
 				},
 				-- refactor related
 				rope = { enabled = true },
 				-- format related
 				black = { enabled = true },
-				pyls_isort = { enabled = true },
 
 				-- disabled tools
 				-- lint related
 				flake8 = { enabled = false },
 				pyflakes = { enabled = false },
 				pycodestyle = { enabled = false },
+				mccabe = { enabled = false },
 				-- format related
+				pyls_isort = { enabled = false },
 				autopep8 = { enabled = false },
 				yapf = { enabled = false },
 			},

--- a/lua/modules/configs/completion/servers/pylsp.lua
+++ b/lua/modules/configs/completion/servers/pylsp.lua
@@ -14,9 +14,9 @@ return {
 					},
 					ignore = {
 						-- ignore E501 (line too long)
-						"E501",
+						-- "E501",
 						-- ignore F401 (imported but unused)
-						"F401",
+						-- "F401",
 					},
 					extendSelect = { "I" },
 				},

--- a/lua/modules/configs/completion/servers/pylsp.lua
+++ b/lua/modules/configs/completion/servers/pylsp.lua
@@ -1,0 +1,28 @@
+return {
+	settings = {
+		pylsp = {
+			plugins = {
+				-- enabled tools
+				-- lint related
+				ruff = {
+					enabled = true,
+					extendSelect = { "I" },
+				},
+				-- refactor related
+				rope = { enabled = true },
+				-- format related
+				black = { enabled = true },
+				pyls_isort = { enabled = true },
+
+				-- disabled tools
+				-- lint related
+				flake8 = { enabled = false },
+				pyflakes = { enabled = false },
+				pycodestyle = { enabled = false },
+				-- format related
+				autopep8 = { enabled = false },
+				yapf = { enabled = false },
+			},
+		},
+	},
+}


### PR DESCRIPTION
I set the default config for `pylsp` and solved the problem in https://github.com/ayamir/nvimdots/issues/767 by enable `ruff` to do lint.

Main config:
1. Use [python-lsp-ruff](https://github.com/python-lsp/python-lsp-ruff) to provide lint function due to its high performance.
2. Use [pylsp-rope](https://github.com/python-rope/pylsp-rope) to provide code refactor function in code action's way as mentioned in https://github.com/ayamir/nvimdots/discussions/708#discussioncomment-5890640.
3. Use [python-lsp-black](https://github.com/python-lsp/python-lsp-black) to provide format function.
4. Remove black config in `null-ls`.
5. Users no need to install or update these plugins manually after `pylsp` installed or updated.

The result: 
![image](https://github.com/ayamir/nvimdots/assets/61657399/3b866ee1-bbc6-4a79-bd9b-2fa2f082d84a)
