### PR TITLE
chore(lsp): set lower pylsp severity

### DIFF
--- a/lua/modules/configs/completion/servers/pylsp.lua
+++ b/lua/modules/configs/completion/servers/pylsp.lua
@@ -19,6 +19,11 @@ return {
 						-- "F401",
 					},
 					extendSelect = { "I" },
+					severities = {
+						-- Hint, Information, Warning, Error
+						F401 = "I",
+						E501 = "I",
+					},
 				},
 				-- refactor related
 				rope = { enabled = true },


### PR DESCRIPTION
https://github.com/python-lsp/python-lsp-ruff/pull/38
Not sure to use "Information" or "Hint", and maybe `settings["diagnostics_virtual_text"] ` should be more controlable so one can define
```lua
	vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
		signs = true,
		underline = true,
		virtual_text = { require("core.settings").diagnostics_virtual_text, severity_limit = "Warning" },
		-- set update_in_insert to false bacause it was enabled by lspsaga
		update_in_insert = false,
	})
```
