### PR TITLE
fix: correct path for pylsp plugins on windows, close #778.

### DIFF
--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -34,6 +34,8 @@ return function()
 		},
 	})
 
+	local is_win = require("core.global").is_windows
+
 	-- Additional plugins for pylsp
 	mason_registry:on(
 		"package:install:success",
@@ -43,9 +45,12 @@ return function()
 			end
 
 			local venv = vim.fn.stdpath("data") .. "/mason/packages/python-lsp-server/venv"
+			local python = is_win and venv .. "/Scripts/python.exe" or venv .. "/bin/python"
+			local black = is_win and venv .. "/Scripts/black.exe" or venv .. "/bin/black"
+			local ruff = is_win and venv .. "/Scripts/ruff.exe" or venv .. "/bin/ruff"
 			require("plenary.job")
 				:new({
-					command = venv .. "/bin/python",
+					command = python,
 					args = {
 						"-m",
 						"pip",
@@ -59,10 +64,7 @@ return function()
 					cwd = venv,
 					env = { VIRTUAL_ENV = venv },
 					on_exit = function()
-						if
-							vim.fn.executable(venv .. "/bin/black") == 1
-							and vim.fn.executable(venv .. "/bin/ruff") == 1
-						then
+						if vim.fn.executable(black) == 1 and vim.fn.executable(ruff) == 1 then
 							vim.notify(
 								"Finished installing pylsp plugins",
 								vim.log.levels.INFO,


### PR DESCRIPTION
@nkta3m

The way to reivew this pr:
1. `git pull`
2. `git switch fix/pylsp-deps-for-win`
3. `nvim somefile.xx`
4. `:Mason`
5. `/` to search `pylsp`
6. hold cursor on the line of `pylsp`
7. if installed, press `u`, else, press `i`
8. wait for success notification.