### PR TITLE
pref(cmp): reduce max entry count to 150

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -106,7 +106,7 @@ return function()
 		},
 		performance = {
 			async_budget = 1,
-			max_view_entries = 300,
+			max_view_entries = 150,
 		},
 		-- You can set mappings if you want
 		mapping = cmp.mapping.preset.insert({


### PR DESCRIPTION
`max_view_entries` is used to limit the number of items listed in the _autocomplete list_, so there's no need to set it to such a large value.