### PR TITLE
fix(options): correct scroll behaviors of (h)splits

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -73,7 +73,7 @@ local function load_options()
 		smarttab = true,
 		softtabstop = 4,
 		splitbelow = true,
-		splitkeep = "cursor",
+		splitkeep = "screen",
 		splitright = true,
 		startofline = false,
 		swapfile = false,


### PR DESCRIPTION
Just found out that we removed `stabilize.nvim` but forgot to set the corresponding option :)