### PR TITLE
perf(lualine): more efficient `has_git` checks

### DIFF
--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -11,6 +11,7 @@ return function()
 	local function custom_theme()
 		vim.api.nvim_create_autocmd("ColorScheme", {
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
+			pattern = "*",
 			callback = function()
 				require("lualine").setup({ options = { theme = custom_theme() } })
 			end,
@@ -72,9 +73,13 @@ return function()
 			return vim.bo.filetype ~= ""
 		end,
 		has_git = function()
-			local filepath = vim.fn.expand("%:p:h")
-			local gitdir = vim.fn.finddir(".git", filepath .. ";")
-			return gitdir and #gitdir > 0 and #gitdir < #filepath
+			local gitdir = vim.fs.find(".git", {
+				limit = 1,
+				upward = true,
+				type = "directory",
+				path = vim.fn.expand("%:p:h"),
+			})
+			return #gitdir > 0
 		end,
 	}
 
@@ -267,7 +272,7 @@ return function()
 					icon = { align = "left" },
 				},
 				components.file_status,
-				vim.tbl_deep_extend("force", components.separator, {
+				vim.tbl_extend("force", components.separator, {
 					cond = function()
 						return conditionals.has_git() and conditionals.has_comp_before()
 					end,
@@ -278,6 +283,7 @@ return function()
 					"branch",
 					icon = icons.git_nosep.Branch,
 					color = utils.gen_hl("subtext0", true, true, nil, "bold"),
+					cond = conditionals.has_git,
 				},
 				{
 					"diff",
@@ -289,6 +295,7 @@ return function()
 					source = diff_source,
 					colored = false,
 					color = utils.gen_hl("subtext0", true, true),
+					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},
 


### PR DESCRIPTION
This works b/c `finddir()` searches bidirectionally _(downward searches are recursive and may search through many directories)_.

This commit instructs `fs.find` to only traverse upward through parent directories and terminate as long as a match is found.