### PR TITLE
workaround(lsp-signature)!: fix input delay of nvim-cmp

### DIFF
--- a/lua/modules/configs/completion/lsp-signature.lua
+++ b/lua/modules/configs/completion/lsp-signature.lua
@@ -1,0 +1,15 @@
+return function()
+	require("lsp_signature").setup({
+		bind = true,
+		-- TODO: Remove the following line when nvim-cmp#1613 gets resolved
+		check_completion_visible = false,
+		floating_window = true,
+		floating_window_above_cur_line = true,
+		hi_parameter = "Search",
+		hint_enable = true,
+		transparency = nil, -- disabled by default, allow floating win transparent value 1~100
+		wrap = true,
+		zindex = 45, -- avoid overlap with nvim.cmp
+		handler_opts = { border = "single" },
+	})
+end

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -97,9 +97,6 @@ return function()
 		ensure_installed = require("core.settings").lsp_deps,
 	})
 
-	local capabilities = vim.lsp.protocol.make_client_capabilities()
-	capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
-
 	vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
 		signs = true,
 		underline = true,
@@ -111,22 +108,8 @@ return function()
 	})
 
 	local opts = {
-		on_attach = function()
-			require("lsp_signature").on_attach({
-				bind = true,
-				use_lspsaga = false,
-				floating_window = true,
-				fix_pos = true,
-				hint_enable = true,
-				hi_parameter = "Search",
-				handler_opts = {
-					border = "single",
-				},
-			})
-		end,
-		capabilities = capabilities,
+		capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol.make_client_capabilities()),
 	}
-
 	---A handler to setup all servers defined under `completion/servers/*.lua`
 	---@param lsp_name string
 	local function mason_lsp_handler(lsp_name)

--- a/lua/modules/configs/lang/rust-tools.lua
+++ b/lua/modules/configs/lang/rust-tools.lua
@@ -4,23 +4,7 @@ return function()
 
 			-- how to execute terminal commands
 			-- options right now: termopen / quickfix
-			executor = require("rust-tools/executors").termopen,
-
-			-- callback to execute once rust-analyzer is done initializing the workspace
-			-- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
-			on_initialized = function()
-				require("lsp_signature").on_attach({
-					bind = true,
-					use_lspsaga = false,
-					floating_window = true,
-					fix_pos = true,
-					hint_enable = true,
-					hi_parameter = "Search",
-					handler_opts = {
-						border = "rounded",
-					},
-				})
-			end,
+			executor = require("rust-tools.executors").termopen,
 
 			-- automatically call RustReloadWorkspace when writing to a Cargo.toml file.
 			reload_workspace_from_cargo_toml = true,

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -7,7 +7,10 @@ completion["neovim/nvim-lspconfig"] = {
 	dependencies = {
 		{ "williamboman/mason.nvim" },
 		{ "williamboman/mason-lspconfig.nvim" },
-		{ "ray-x/lsp_signature.nvim" },
+		{
+			"ray-x/lsp_signature.nvim",
+			config = require("completion.lsp-signature"),
+		},
 	},
 }
 completion["nvimdev/lspsaga.nvim"] = {


### PR DESCRIPTION
* `on_attach` [is deprecated](https://github.com/ray-x/lsp_signature.nvim/blob/17ff7a405fea8376b015b8ea7910d2e59958bf68/doc/lsp_signature.txt#L148-L149);
* Now `lsp_signature` won't adjust its position relative to the completion popup to avoid problematic functions (cmp.visible) being called.