### PR TITLE
migrate: install `rustfmt` from `rustup` (#842)

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -99,7 +99,6 @@ settings["lsp_deps"] = {
 settings["null_ls_deps"] = {
 	"clang_format",
 	"prettier",
-	"rustfmt",
 	"shfmt",
 	"stylua",
 	"vint",


### PR DESCRIPTION
Should we include `rustup` installation in our installation scripts?
Besides `rustfmt`, `sniprun` also needs `cargo` to compile, so I think it might be acceptable to add it.
cc @Jint-lzxy @ClSlaid @volpan  