### PR TITLE
Fix the issue of slow file opening and operation due to too many tree sitter errors

### DIFF
--- a/lua/modules/configs/editor/rainbow_delims.lua
+++ b/lua/modules/configs/editor/rainbow_delims.lua
@@ -1,7 +1,13 @@
 return function()
 	vim.g.rainbow_delimiters = {
 		strategy = {
-			[""] = require("rainbow-delimiters").strategy["local"],
+			[""] = function()
+				local ok, is_large_file = pcall(vim.api.nvim_buf_get_var, vim.fn.bufnr(), "bigfile_disable_treesitter")
+				if ok and is_large_file then
+					return nil
+				end
+				return require("rainbow-delimiters").strategy["global"]
+			end,
 		},
 		query = {
 			[""] = "rainbow-delimiters",


### PR DESCRIPTION
Ref：https://github.com/HiPhish/rainbow-delimiters.nvim/issues/12

The repair method in the reference is to calculate the number of errors but I think it's better to use the same operation as the treesitter.

Please see if this is OK, at least It work well when I test it