### PR TITLE
feat(dap)!: support integrated terminals (io in neovim)

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _toggle_lazygit _command_panel _dap_mainbuf_nr --max-line-length 150 --no-config
+          args: . --std luajit --globals vim _toggle_lazygit _command_panel --max-line-length 150 --no-config

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _toggle_lazygit _command_panel --max-line-length 150 --no-config
+          args: . --std luajit --globals vim _toggle_lazygit _command_panel _dap_mainbuf_nr --max-line-length 150 --no-config

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -145,7 +145,6 @@ local plug_map = {
 		:with_desc("debug: Run/Continue"),
 	["n|<F7>"] = map_callback(function()
 			require("dap").terminate()
-			require("dapui").close()
 		end)
 		:with_noremap()
 		:with_silent()

--- a/lua/modules/configs/editor/rainbow_delims.lua
+++ b/lua/modules/configs/editor/rainbow_delims.lua
@@ -10,7 +10,7 @@ return function()
 			if errors < 0 then
 				return nil
 			end
-			return (check_lines and vim.fn.line("$") > 450) and require("rainbow-delimiters").strategy["global"]
+			return (check_lines and vim.fn.line("$") > 350) and require("rainbow-delimiters").strategy["global"]
 				or require("rainbow-delimiters").strategy["local"]
 		end
 	end
@@ -20,6 +20,8 @@ return function()
 			[""] = init_strategy(false),
 			c = init_strategy(true),
 			cpp = init_strategy(true),
+			vimdoc = init_strategy(true),
+			vim = init_strategy(true),
 		},
 		query = {
 			[""] = "rainbow-delimiters",

--- a/lua/modules/configs/tool/dap/clients/codelldb.lua
+++ b/lua/modules/configs/tool/dap/clients/codelldb.lua
@@ -15,7 +15,7 @@ return function()
 	}
 	dap.configurations.c = {
 		{
-			name = "Launch the debugger",
+			name = "Debug",
 			type = "codelldb",
 			request = "launch",
 			program = utils.input_exec_path(),
@@ -24,7 +24,7 @@ return function()
 			terminal = "integrated",
 		},
 		{
-			name = "Launch the debugger (with args)",
+			name = "Debug (with args)",
 			type = "codelldb",
 			request = "launch",
 			program = utils.input_exec_path(),

--- a/lua/modules/configs/tool/dap/clients/codelldb.lua
+++ b/lua/modules/configs/tool/dap/clients/codelldb.lua
@@ -19,9 +19,27 @@ return function()
 			type = "codelldb",
 			request = "launch",
 			program = utils.input_exec_path(),
+			cwd = "${workspaceFolder}",
+			stopOnEntry = false,
+			terminal = "integrated",
+		},
+		{
+			name = "Launch the debugger (with args)",
+			type = "codelldb",
+			request = "launch",
+			program = utils.input_exec_path(),
 			args = utils.input_args(),
 			cwd = "${workspaceFolder}",
 			stopOnEntry = false,
+			terminal = "integrated",
+		},
+		{
+			name = "Attach to a running process",
+			type = "codelldb",
+			request = "attach",
+			program = utils.input_exec_path(),
+			stopOnEntry = false,
+			waitFor = true,
 		},
 	}
 	dap.configurations.cpp = dap.configurations.c

--- a/lua/modules/configs/tool/dap/clients/lldb.lua
+++ b/lua/modules/configs/tool/dap/clients/lldb.lua
@@ -5,8 +5,7 @@ return function()
 
 	dap.adapters.lldb = {
 		type = "executable",
-		command = "lldb-vscode",
-		name = "lldb",
+		command = vim.fn.exepath("lldb-vscode"), -- Find lldb-vscode on $PATH
 	}
 	dap.configurations.c = {
 		{

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -1,7 +1,9 @@
 -- https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#python
+-- https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
 return function()
 	local dap = require("dap")
 	local debugpy = vim.fn.exepath("debugpy-adapter")
+	local utils = require("modules.utils.dap")
 
 	local function is_empty(s)
 		return s == nil or s == ""
@@ -9,9 +11,7 @@ return function()
 
 	dap.adapters.python = function(callback, config)
 		if config.request == "attach" then
-			---@diagnostic disable-next-line: undefined-field
 			local port = (config.connect or config).port
-			---@diagnostic disable-next-line: undefined-field
 			local host = (config.connect or config).host or "127.0.0.1"
 			callback({
 				type = "server",
@@ -32,9 +32,10 @@ return function()
 			-- The first three options are required by nvim-dap
 			type = "python", -- the type here established the link to the adapter definition: `dap.adapters.python`
 			request = "launch",
-			name = "Launch file",
+			name = "Debug",
 			-- Options below are for debugpy, see https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings for supported options
-			program = "${file}", -- This configuration will launch the current file if used.
+			console = "integratedTerminal",
+			program = utils.input_file_path(),
 			pythonPath = function()
 				if not is_empty(vim.env.CONDA_PREFIX) then
 					return vim.env.CONDA_PREFIX .. "/bin/python"
@@ -44,22 +45,26 @@ return function()
 			end,
 			console = "integratedTerminal",
 		},
+		{
+			-- NOTE: This setting is for people using venv
+			type = "python",
+			request = "launch",
+			name = "Debug (using venv)",
+			-- Options below are for debugpy, see https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings for supported options
+			console = "integratedTerminal",
+			program = utils.input_file_path(),
+			pythonPath = function()
+				local cwd, venv = vim.fn.getcwd(), os.getenv("VIRTUAL_ENV")
+				if venv and vim.fn.executable(venv .. "/bin/python") == 1 then
+					return venv .. "/bin/python"
+				elseif vim.fn.executable(cwd .. "/venv/bin/python") == 1 then
+					return cwd .. "/venv/bin/python"
+				elseif vim.fn.executable(cwd .. "/.venv/bin/python") == 1 then
+					return cwd .. "/.venv/bin/python"
+				else
+					return "python3"
+				end
+			end,
+		},
 	}
-
-	-- NOTE: This setting is for people using venv
-	-- pythonPath = function()
-	-- 	-- debugpy supports launching an application with a different interpreter then the one used to launch debugpy itself.
-	-- 	-- The code below looks for a `venv` or `.venv` folder in the current directly and uses the python within.
-	-- 	-- You could adapt this - to for example use the `VIRTUAL_ENV` environment variable.
-	-- 	local cwd, venv = vim.fn.getcwd(), os.getenv("VIRTUAL_ENV")
-	-- 	if venv and vim.fn.executable(venv .. "/bin/python") == 1 then
-	-- 		return venv .. "/bin/python"
-	-- 	elseif vim.fn.executable(cwd .. "/venv/bin/python") == 1 then
-	-- 		return cwd .. "/venv/bin/python"
-	-- 	elseif vim.fn.executable(cwd .. "/.venv/bin/python") == 1 then
-	-- 		return cwd .. "/.venv/bin/python"
-	-- 	else
-	-- 		return "python3"
-	-- 	end
-	-- end,
 end

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -42,6 +42,7 @@ return function()
 					return "python3"
 				end
 			end,
+			console = "integratedTerminal",
 		},
 	}
 

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -43,7 +43,6 @@ return function()
 					return "python3"
 				end
 			end,
-			console = "integratedTerminal",
 		},
 		{
 			-- NOTE: This setting is for people using venv

--- a/lua/modules/configs/tool/dap/dap-keymap.lua
+++ b/lua/modules/configs/tool/dap/dap-keymap.lua
@@ -16,14 +16,14 @@ local original_keymap = {
 	["v|K"] = map_cmd(":m '<-2<CR>gv=gv"),
 }
 
-function M:load()
+function M.load()
 	if not did_load_debug_mappings then
 		bind.nvim_load_mapping(debug_keymap)
 		did_load_debug_mappings = true
 	end
 end
 
-function M:restore()
+function M.restore()
 	if did_load_debug_mappings then
 		bind.nvim_load_mapping(original_keymap)
 		did_load_debug_mappings = false

--- a/lua/modules/configs/tool/dap/dap-keymap.lua
+++ b/lua/modules/configs/tool/dap/dap-keymap.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+local bind = require("keymap.bind")
+local map_cr = bind.map_cr
+local map_cmd = bind.map_cmd
+
+local did_load_debug_mappings = false
+local debug_keymap = {
+	["nv|K"] = map_cmd("<Cmd>lua require('dapui').eval()<CR>")
+		:with_noremap()
+		:with_nowait()
+		:with_desc("debug: Evaluate expression under cursor"),
+}
+local original_keymap = {
+	["n|K"] = map_cr("Lspsaga hover_doc"):with_noremap():with_silent():with_desc("lsp: Show doc"),
+	["v|K"] = map_cmd(":m '<-2<CR>gv=gv"),
+}
+
+function M:load()
+	if not did_load_debug_mappings then
+		bind.nvim_load_mapping(debug_keymap)
+		did_load_debug_mappings = true
+	end
+end
+
+function M:restore()
+	if did_load_debug_mappings then
+		bind.nvim_load_mapping(original_keymap)
+		did_load_debug_mappings = false
+	end
+end
+
+return M

--- a/lua/modules/configs/tool/dap/dapui.lua
+++ b/lua/modules/configs/tool/dap/dapui.lua
@@ -37,8 +37,8 @@ return function()
 			},
 			{
 				elements = {
-					{ id = "console", size = 0.45 },
-					{ id = "repl", size = 0.55 },
+					{ id = "console", size = 0.55 },
+					{ id = "repl", size = 0.45 },
 				},
 				position = "bottom",
 				size = 0.25,
@@ -67,6 +67,6 @@ return function()
 				close = { "q", "<Esc>" },
 			},
 		},
-		render = { indent = 1, max_value_lines = 120 },
+		render = { indent = 1, max_value_lines = 85 },
 	})
 end

--- a/lua/modules/configs/tool/dap/dapui.lua
+++ b/lua/modules/configs/tool/dap/dapui.lua
@@ -5,14 +5,20 @@ return function()
 	}
 
 	require("dapui").setup({
-		icons = { expanded = icons.ui.ArrowOpen, collapsed = icons.ui.ArrowClosed, current_frame = icons.ui.Indicator },
+		force_buffers = true,
+		icons = {
+			expanded = icons.ui.ArrowOpen,
+			collapsed = icons.ui.ArrowClosed,
+			current_frame = icons.ui.Indicator,
+		},
 		mappings = {
 			-- Use a table to apply multiple mappings
+			edit = "e",
 			expand = { "<CR>", "<2-LeftMouse>" },
 			open = "o",
 			remove = "d",
-			edit = "e",
 			repl = "r",
+			toggle = "t",
 		},
 		layouts = {
 			{
@@ -20,18 +26,24 @@ return function()
 					-- Provide as ID strings or tables with "id" and "size" keys
 					{
 						id = "scopes",
-						size = 0.25, -- Can be float or integer > 1
+						size = 0.3, -- Can be float or integer > 1
 					},
-					{ id = "breakpoints", size = 0.25 },
-					{ id = "stacks", size = 0.25 },
-					{ id = "watches", size = 0.25 },
+					{ id = "watches", size = 0.3 },
+					{ id = "stacks", size = 0.3 },
+					{ id = "breakpoints", size = 0.1 },
 				},
-				size = 40,
-				position = "left",
+				size = 0.3,
+				position = "right",
 			},
-			{ elements = { "repl" }, size = 10, position = "bottom" },
+			{
+				elements = {
+					{ id = "console", size = 0.45 },
+					{ id = "repl", size = 0.55 },
+				},
+				position = "bottom",
+				size = 0.25,
+			},
 		},
-		-- Requires Nvim version >= 0.8
 		controls = {
 			enabled = true,
 			-- Display controls in this session
@@ -48,10 +60,13 @@ return function()
 			},
 		},
 		floating = {
-			max_height = nil,
-			max_width = nil,
-			mappings = { close = { "q", "<Esc>" } },
+			max_height = nil, -- These can be integers or a float between 0 and 1.
+			max_width = nil, -- Floats will be treated as percentage of your screen.
+			border = "single", -- Border style. Can be "single", "double" or "rounded"
+			mappings = {
+				close = { "q", "<Esc>" },
+			},
 		},
-		windows = { indent = 1 },
+		render = { indent = 1, max_value_lines = 120 },
 	})
 end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -5,33 +5,18 @@ return function()
 
 	local icons = { dap = require("modules.utils.icons").get("dap") }
 	local colors = require("modules.utils").get_palette()
+	local mapping = require("tool.dap.dap-keymap")
 
 	-- Initialize debug hooks
 	local function debug_init_cb()
-		_G._dap_mainbuf_nr = vim.fn.bufnr()
-		vim.api.nvim_buf_set_keymap(
-			_dap_mainbuf_nr,
-			"n",
-			"K",
-			"<Cmd>lua require('dapui').eval()<CR>",
-			{ noremap = true, nowait = true }
-		)
-		vim.api.nvim_buf_set_keymap(
-			_dap_mainbuf_nr,
-			"v",
-			"K",
-			"<Cmd>lua require('dapui').eval()<CR>",
-			{ noremap = true, nowait = true }
-		)
-
+		_G._debugging = true
+		mapping:load()
 		dapui.open()
 	end
 	local function debug_terminate_cb()
-		if _dap_mainbuf_nr then
-			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "n", "K")
-			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "v", "K")
-			_G._dap_mainbuf_nr = nil
-
+		if _debugging then
+			_G._debugging = false
+			mapping:restore()
 			dapui.close()
 		end
 	end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -5,18 +5,21 @@ return function()
 
 	local icons = { dap = require("modules.utils.icons").get("dap") }
 	local colors = require("modules.utils").get_palette()
-	local mapping = require("tool.dap.dap-keymap")
+	local mappings = require("tool.dap.dap-keymap")
 
 	-- Initialize debug hooks
+	local _debugging = false
 	local function debug_init_cb()
-		_G._debugging = true
-		mapping:load()
-		dapui.open()
+		if not _debugging then
+			_debugging = true
+			mappings.load()
+			dapui.open()
+		end
 	end
 	local function debug_terminate_cb()
 		if _debugging then
-			_G._debugging = false
-			mapping:restore()
+			_debugging = false
+			mappings.restore()
 			dapui.close()
 		end
 	end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -7,12 +7,37 @@ return function()
 	local colors = require("modules.utils").get_palette()
 
 	dap.listeners.after.event_initialized["dapui_config"] = function()
+		_G._dap_mainbuf_nr = vim.fn.bufnr()
+		vim.api.nvim_buf_set_keymap(
+			_dap_mainbuf_nr,
+			"n",
+			"K",
+			"<Cmd>lua require('dapui').eval()<CR>",
+			{ noremap = true, nowait = true }
+		)
+		vim.api.nvim_buf_set_keymap(
+			_dap_mainbuf_nr,
+			"v",
+			"K",
+			"<Cmd>lua require('dapui').eval()<CR>",
+			{ noremap = true, nowait = true }
+		)
 		dapui.open()
 	end
 	dap.listeners.after.event_terminated["dapui_config"] = function()
+		if _dap_mainbuf_nr then
+			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "n", "K")
+			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "v", "K")
+			_G._dap_mainbuf_nr = nil
+		end
 		dapui.close()
 	end
 	dap.listeners.after.event_exited["dapui_config"] = function()
+		if _dap_mainbuf_nr then
+			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "n", "K")
+			vim.api.nvim_buf_del_keymap(_dap_mainbuf_nr, "v", "K")
+			_G._dap_mainbuf_nr = nil
+		end
 		dapui.close()
 	end
 

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -10,11 +10,9 @@ return function()
 	-- Initialize debug hooks
 	local _debugging = false
 	local function debug_init_cb()
-		if not _debugging then
-			_debugging = true
-			mappings.load()
-			dapui.open()
-		end
+		_debugging = true
+		mappings.load()
+		dapui.open({ reset = true })
 	end
 	local function debug_terminate_cb()
 		if _debugging then

--- a/lua/modules/utils/dap.lua
+++ b/lua/modules/utils/dap.lua
@@ -6,7 +6,11 @@ function M.input_args()
 end
 
 function M.input_exec_path()
-	return vim.fn.input('Path to executable (default to "a.out"): ', vim.fn.expand("%:p:h") .. "/a.out", "file")
+	return vim.fn.input('Path to executable (default to "progout"): ', vim.fn.expand("%:p:h") .. "/progout", "file")
+end
+
+function M.input_file_path()
+	return vim.fn.input("Path to debuggee (default to the current file): ", vim.fn.expand("%:p"), "file")
 end
 
 function M.get_env()

--- a/lua/modules/utils/dap.lua
+++ b/lua/modules/utils/dap.lua
@@ -6,7 +6,7 @@ function M.input_args()
 end
 
 function M.input_exec_path()
-	return vim.fn.input('Path to executable (default to "progout"): ', vim.fn.expand("%:p:h") .. "/progout", "file")
+	return vim.fn.input('Path to executable (default to "a.out"): ', vim.fn.expand("%:p:h") .. "/a.out", "file")
 end
 
 function M.input_file_path()


### PR DESCRIPTION
Recent updates to `nvim-dap` made integrated terminals possibe right inside Neovim. This PR implemented basic support for this feature, but it's still necessary to adjust the settings of each debugger to correctly redirect stdio to the specified terminal (inside Neovim). More info: [dap-terminal](https://github.com/mfussenegger/nvim-dap/blob/d17d1bba23ec72a157bd183c57840c39e323f515/doc/dap.txt#L549-L602).

I'm not that familiar with other debuggers so I only adjusted the settings for `codelldb` (AFAIK `lldb-vscode` has zero support for IO redirection). Someone who understands these _other_ debuggers could help make several changes before merging :) Any help will be appreciated!

Aditionally, `K` (responsible for `require('dapui').eval()`) will be set as a buffer-local keymap (mode: `n|v`) when a session initiates. We may need to document this in the Wiki.

Related: #416, #440, #592