### PR TITLE
fix(lspkind): `TypeParams` shall be `colors.blue` (FNC)

### DIFF
--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -185,7 +185,7 @@ function M.gen_lspkind_hl()
 		Package = colors.blue,
 		Property = colors.teal,
 		Struct = colors.yellow,
-		TypeParameter = colors.maroon,
+		TypeParameter = colors.blue,
 		Variable = colors.peach,
 		Array = colors.peach,
 		Boolean = colors.peach,


### PR DESCRIPTION
Ref: https://github.com/Jint-lzxy/nvim/commit/d9989a56380f4c30f8fda41eb9a9ac0932d4f383