### PR TITLE
fix(dap-keymap): simplify keymap implementation

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _toggle_lazygit _command_panel _lspkeymap_loaded_bufnr --max-line-length 150 --no-config
+          args: . --std luajit --globals vim _toggle_lazygit _command_panel _buf_with_lsp --max-line-length 150 --no-config

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _toggle_lazygit _command_panel _buf_with_lsp --max-line-length 150 --no-config
+          args: . --std luajit --globals vim _toggle_lazygit _command_panel _debugging --max-line-length 150 --no-config

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -14,14 +14,10 @@ function autocmd.nvim_create_augroups(definitions)
 end
 
 local mapping = require("keymap.completion")
-_G._buf_with_lsp = {}
 vim.api.nvim_create_autocmd("LspAttach", {
 	group = vim.api.nvim_create_augroup("LspKeymapLoader", { clear = true }),
 	callback = function(event)
-		if not _buf_with_lsp[event.buf] then
-			mapping.lsp(event.buf)
-			_buf_with_lsp[event.buf] = true
-		end
+		mapping.lsp(event.buf)
 	end,
 })
 

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -14,13 +14,13 @@ function autocmd.nvim_create_augroups(definitions)
 end
 
 local mapping = require("keymap.completion")
-_G._lspkeymap_loaded_bufnr = {}
+_G._buf_with_lsp = {}
 vim.api.nvim_create_autocmd("LspAttach", {
 	group = vim.api.nvim_create_augroup("LspKeymapLoader", { clear = true }),
 	callback = function(event)
-		if not _lspkeymap_loaded_bufnr[event.buf] then
+		if not _buf_with_lsp[event.buf] then
 			mapping.lsp(event.buf)
-			_lspkeymap_loaded_bufnr[event.buf] = true
+			_buf_with_lsp[event.buf] = true
 		end
 	end,
 })

--- a/lua/modules/configs/tool/dap/dap-keymap.lua
+++ b/lua/modules/configs/tool/dap/dap-keymap.lua
@@ -1,58 +1,20 @@
 local M = {}
 
-local did_load_debug_mappings = false
+local bind = require("keymap.bind")
+local map_cmd = bind.map_cmd
 
-local function remove_lsp_keymap(mode, map)
-	for buf in pairs(_G._buf_with_lsp) do
-		vim.api.nvim_buf_del_keymap(buf, mode, map)
-	end
-end
-local function restore_lsp_keymap(mode, map, rhs, options)
-	for buf in pairs(_G._buf_with_lsp) do
-		vim.api.nvim_buf_set_keymap(buf, mode, map, rhs, options)
-	end
-end
+local did_load_debug_mappings = false
+local debug_keymap = {
+	["nv|K"] = map_cmd("<Cmd>lua require('dapui').eval()<CR>")
+		:with_noremap()
+		:with_nowait()
+		:with_desc("Evaluate expression under cursor"),
+}
 
 function M.load_extras()
 	if not did_load_debug_mappings then
-		remove_lsp_keymap("n", "K")
-		vim.api.nvim_del_keymap("v", "K")
-		vim.api.nvim_set_keymap("n", "K", "<Cmd>lua require('dapui').eval()<CR>", {
-			desc = "debug: Evaluate expression under cursor",
-			expr = false,
-			noremap = true,
-			nowait = true,
-			silent = true,
-		})
-		vim.api.nvim_set_keymap("v", "K", "<Cmd>lua require('dapui').eval()<CR>", {
-			desc = "debug: Evaluate expression under cursor",
-			expr = false,
-			noremap = true,
-			nowait = true,
-			silent = true,
-		})
+		require("modules.utils.keymap").amend("Debugging", "_debugging", debug_keymap)
 		did_load_debug_mappings = true
-	end
-end
-
-function M.restore()
-	if did_load_debug_mappings then
-		vim.api.nvim_del_keymap("n", "K")
-		vim.api.nvim_del_keymap("v", "K")
-		restore_lsp_keymap("n", "K", ":Lspsaga hover_doc<CR>", {
-			desc = "lsp: Show doc",
-			expr = false,
-			noremap = true,
-			nowait = false,
-			silent = true,
-		})
-		vim.api.nvim_set_keymap("v", "K", ":m '<-2<CR>gv=gv", {
-			expr = false,
-			noremap = false,
-			nowait = false,
-			silent = false,
-		})
-		did_load_debug_mappings = false
 	end
 end
 

--- a/lua/modules/configs/tool/dap/dap-keymap.lua
+++ b/lua/modules/configs/tool/dap/dap-keymap.lua
@@ -1,76 +1,57 @@
 local M = {}
 
-local bind = require("keymap.bind")
-local map_cr = bind.map_cr
-local map_cmd = bind.map_cmd
-
 local did_load_debug_mappings = false
-local keymap_info_debug = {
-	n = { K = false },
-	v = { K = false },
-}
-local keymap_info_original = {
-	n = { K = true },
-	v = { K = false },
-}
-local debug_keymap = {
-	["nv|K"] = map_cmd("<Cmd>lua require('dapui').eval()<CR>")
-		:with_noremap()
-		:with_nowait()
-		:with_desc("debug: Evaluate expression under cursor"),
-}
-local original_keymap = {
-	["n|K"] = map_cr("Lspsaga hover_doc"):with_noremap():with_silent():with_desc("lsp: Show doc"),
-	["v|K"] = map_cmd(":m '<-2<CR>gv=gv"),
-}
 
-local function del_keymap(mappings, keymap_info)
-	for key in pairs(mappings) do
-		local modes, keymap = key:match("([^|]*)|?(.*)")
-		for _, mode in ipairs(vim.split(modes, "")) do
-			if vim.fn.maparg(keymap, mode, false) ~= "" then
-				if keymap_info[mode][keymap] == true then
-					vim.api.nvim_buf_del_keymap(0, mode, keymap)
-				else
-					vim.api.nvim_del_keymap(mode, keymap)
-				end
-			end
-		end
+local function remove_lsp_keymap(mode, map)
+	for buf in pairs(_G._buf_with_lsp) do
+		vim.api.nvim_buf_del_keymap(buf, mode, map)
+	end
+end
+local function restore_lsp_keymap(mode, map, rhs, options)
+	for buf in pairs(_G._buf_with_lsp) do
+		vim.api.nvim_buf_set_keymap(buf, mode, map, rhs, options)
 	end
 end
 
-local function load_keymap(mappings, keymap_info)
-	for key, value in pairs(mappings) do
-		local modes, keymap = key:match("([^|]*)|?(.*)")
-		if type(value) == "table" then
-			for _, mode in ipairs(vim.split(modes, "")) do
-				local rhs = value.cmd
-				local options = value.options
-				if keymap_info[mode][keymap] == true then
-					for buf in pairs(_G._lspkeymap_loaded_bufnr) do
-						-- Restore lsp keymaps
-						vim.api.nvim_buf_set_keymap(buf, mode, keymap, rhs, options)
-					end
-				else
-					vim.api.nvim_set_keymap(mode, keymap, rhs, options)
-				end
-			end
-		end
-	end
-end
-
-function M.load()
+function M.load_extras()
 	if not did_load_debug_mappings then
-		del_keymap(original_keymap, keymap_info_original)
-		load_keymap(debug_keymap, keymap_info_debug)
+		remove_lsp_keymap("n", "K")
+		vim.api.nvim_del_keymap("v", "K")
+		vim.api.nvim_set_keymap("n", "K", "<Cmd>lua require('dapui').eval()<CR>", {
+			desc = "debug: Evaluate expression under cursor",
+			expr = false,
+			noremap = true,
+			nowait = true,
+			silent = true,
+		})
+		vim.api.nvim_set_keymap("v", "K", "<Cmd>lua require('dapui').eval()<CR>", {
+			desc = "debug: Evaluate expression under cursor",
+			expr = false,
+			noremap = true,
+			nowait = true,
+			silent = true,
+		})
 		did_load_debug_mappings = true
 	end
 end
 
 function M.restore()
 	if did_load_debug_mappings then
-		del_keymap(debug_keymap, keymap_info_debug)
-		load_keymap(original_keymap, keymap_info_original)
+		vim.api.nvim_del_keymap("n", "K")
+		vim.api.nvim_del_keymap("v", "K")
+		restore_lsp_keymap("n", "K", ":Lspsaga hover_doc<CR>", {
+			desc = "lsp: Show doc",
+			expr = false,
+			noremap = true,
+			nowait = false,
+			silent = true,
+		})
+		vim.api.nvim_set_keymap("v", "K", ":m '<-2<CR>gv=gv", {
+			expr = false,
+			noremap = false,
+			nowait = false,
+			silent = false,
+		})
 		did_load_debug_mappings = false
 	end
 end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -11,7 +11,7 @@ return function()
 	local _debugging = false
 	local function debug_init_cb()
 		_debugging = true
-		mappings.load()
+		mappings.load_extras()
 		dapui.open({ reset = true })
 	end
 	local function debug_terminate_cb()

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -8,16 +8,15 @@ return function()
 	local mappings = require("tool.dap.dap-keymap")
 
 	-- Initialize debug hooks
-	local _debugging = false
+	_G._debugging = false
 	local function debug_init_cb()
-		_debugging = true
+		_G._debugging = true
 		mappings.load_extras()
 		dapui.open({ reset = true })
 	end
 	local function debug_terminate_cb()
 		if _debugging then
-			_debugging = false
-			mappings.restore()
+			_G._debugging = false
 			dapui.close()
 		end
 	end

--- a/lua/modules/utils/keymap.lua
+++ b/lua/modules/utils/keymap.lua
@@ -1,0 +1,144 @@
+local M = {}
+
+---Shortcut for `nvim_replace_termcodes`.
+---@param keys string
+---@return string
+local function termcodes(keys)
+	return vim.api.nvim_replace_termcodes(keys, true, true, true)
+end
+
+---Returns if two key sequence are equal or not.
+---@param a string
+---@param b string
+---@return boolean
+local function keymap_equals(a, b)
+	return termcodes(a) == termcodes(b)
+end
+
+---Get map
+---@param mode string
+---@param lhs string
+---@return table
+local function get_map(mode, lhs)
+	for _, map in ipairs(vim.api.nvim_buf_get_keymap(0, mode)) do
+		if keymap_equals(map.lhs, lhs) then
+			return {
+				lhs = map.lhs,
+				rhs = map.rhs or "",
+				expr = map.expr == 1,
+				callback = map.callback,
+				noremap = map.noremap == 1,
+				script = map.script == 1,
+				silent = map.silent == 1,
+				nowait = map.nowait == 1,
+				buffer = true,
+			}
+		end
+	end
+
+	for _, map in ipairs(vim.api.nvim_get_keymap(mode)) do
+		if keymap_equals(map.lhs, lhs) then
+			return {
+				lhs = map.lhs,
+				rhs = map.rhs or "",
+				expr = map.expr == 1,
+				callback = map.callback,
+				noremap = map.noremap == 1,
+				script = map.script == 1,
+				silent = map.silent == 1,
+				nowait = map.nowait == 1,
+				buffer = false,
+			}
+		end
+	end
+
+	return {
+		lhs = lhs,
+		rhs = lhs,
+		expr = false,
+		callback = nil,
+		noremap = true,
+		script = false,
+		silent = true,
+		nowait = false,
+		buffer = false,
+	}
+end
+
+---Returns the function constructed from the passed keymap object on call of
+---which the original keymapping will be executed.
+---@param map table keymap object
+---@return function
+local function get_original(map)
+	return function()
+		local keys, fmode
+		if map.expr then
+			if map.callback then
+				keys = map.callback()
+			else
+				keys = vim.api.nvim_eval(map.rhs)
+			end
+		elseif map.callback then
+			map.callback()
+			return
+		else
+			keys = map.rhs
+		end
+		keys = termcodes(keys)
+		fmode = map.noremap and "in" or "im"
+		vim.api.nvim_feedkeys(keys, fmode, false)
+	end
+end
+
+---@param cond string
+---@param mode string
+---@param lhs string
+---@param rhs string | function
+---@param opts? table
+local function amend(cond, mode, lhs, rhs, opts)
+	local map = get_map(mode, lhs)
+	local original = get_original(map)
+	opts = opts or {}
+	opts.desc = table.concat({
+		"[" .. cond,
+		(opts.desc and ": " .. opts.desc or ""),
+		"] / ",
+		map.desc or "",
+	})
+	vim.keymap.set(mode, lhs, function()
+		rhs(original)
+	end, opts)
+end
+
+---Amend the existing keymap.
+---@param cond string
+---@param mode string | string[]
+---@param lhs string
+---@param rhs string | function
+---@param opts? table
+local function modes_amend(cond, mode, lhs, rhs, opts)
+	if type(mode) == "table" then
+		for _, m in ipairs(mode) do
+			amend(cond, m, lhs, rhs, opts)
+		end
+	else
+		amend(cond, mode, lhs, rhs, opts)
+	end
+end
+
+---@param cond string
+---@param mapping table<string, map_rhs>
+function M.amend(cond, mapping)
+	for key, value in pairs(mapping) do
+		local modes, keymap = key:match("([^|]*)|?(.*)")
+		if type(value) == "table" then
+			for _, mode in ipairs(vim.split(modes, "")) do
+				local rhs = value.cmd
+				local options = value.options
+				modes_amend(cond, mode, keymap, rhs, options)
+			end
+		end
+	end
+end
+
+return M


### PR DESCRIPTION
IMO the cognitive complexity of changes introduced by #902 is too high. This PR makes `dap-keymap.lua` do whatever it should have done - delete old keymaps and restore them when appropriate.