### PR TITLE
fix toggleterm & add config for diffview.nvim

### DIFF
--- a/lua/modules/configs/editor/diffview.lua
+++ b/lua/modules/configs/editor/diffview.lua
@@ -1,0 +1,9 @@
+return function()
+	require("diffview").setup({
+		view = {
+			merge_tool = {
+				disable_diagnostics = true,
+			},
+		},
+	})
+end

--- a/lua/modules/configs/tool/toggleterm.lua
+++ b/lua/modules/configs/tool/toggleterm.lua
@@ -31,6 +31,7 @@ return function()
 		shade_terminals = false,
 		shading_factor = "1", -- the degree by which to darken to terminal colour, default: 1 for dark backgrounds, 3 for light
 		start_in_insert = true,
+        persist_mode = false,
 		insert_mappings = true, -- whether or not the open mapping applies in insert mode
 		persist_size = true,
 		direction = "horizontal",

--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -51,6 +51,7 @@ editor["numToStr/Comment.nvim"] = {
 editor["sindrets/diffview.nvim"] = {
 	lazy = true,
 	cmd = { "DiffviewOpen", "DiffviewClose" },
+	config = require("editor.diffview")
 }
 editor["junegunn/vim-easy-align"] = {
 	lazy = true,


### PR DESCRIPTION
1. `toggleterm.nvim`: fix toggleterm `start_in_insert` not working.
2. `diffview.nvim`: disable lsp diagnostics in Diffview mode, otherwise, lsp goes crazy due to the conflict markers (<<<) and then crashes. 