### PR TITLE
fix: only disable autoclose for specific filetypes

### DIFF
--- a/lua/modules/configs/editor/autoclose.lua
+++ b/lua/modules/configs/editor/autoclose.lua
@@ -5,15 +5,15 @@ return function()
 			["["] = { escape = false, close = true, pair = "[]" },
 			["{"] = { escape = false, close = true, pair = "{}" },
 
-			["<"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
-			[">"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
 			[")"] = { escape = true, close = false, pair = "()" },
 			["]"] = { escape = true, close = false, pair = "[]" },
 			["}"] = { escape = true, close = false, pair = "{}" },
 
 			['"'] = { escape = true, close = true, pair = '""' },
-			["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = { "rust" } },
 			["`"] = { escape = true, close = true, pair = "``" },
+			["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = { "rust" } },
+			["<"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
+			[">"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
 		},
 		options = {
 			disabled_filetypes = { "big_file_disabled_ft" },

--- a/lua/modules/configs/editor/autoclose.lua
+++ b/lua/modules/configs/editor/autoclose.lua
@@ -5,13 +5,14 @@ return function()
 			["["] = { escape = false, close = true, pair = "[]" },
 			["{"] = { escape = false, close = true, pair = "{}" },
 
-			[">"] = { escape = true, close = false, pair = "<>" },
+			["<"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
+			[">"] = { escape = true, close = true, pair = "<>", disabled_filetypes = { "cpp" } },
 			[")"] = { escape = true, close = false, pair = "()" },
 			["]"] = { escape = true, close = false, pair = "[]" },
 			["}"] = { escape = true, close = false, pair = "{}" },
 
 			['"'] = { escape = true, close = true, pair = '""' },
-			["'"] = { escape = true, close = true, pair = "''" },
+			["'"] = { escape = true, close = true, pair = "''", disabled_filetypes = { "rust" } },
 			["`"] = { escape = true, close = true, pair = "``" },
 		},
 		options = {


### PR DESCRIPTION
1. disable autoclose `''` for **rust** because `'` is the symbol for lifetimes.
2. disable autoclose `<>` for **cpp only** because `<<` and `>>` are operators in cpp but `<>` is often used as generic type.