### PR TITLE
feat(lspsaga): make codeaction effective linewise

### DIFF
--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -53,6 +53,7 @@ return function()
 		-- https://dev.neovim.pro/lspsaga/codeaction/
 		code_action = {
 			num_shortcut = true,
+			only_in_cursor = false,
 			show_server_name = true,
 			extend_gitsigns = false,
 			keys = {


### PR DESCRIPTION
IMO It's pretty counterintuitive to have cursor placed on the target identifier before toggling code action(s). This PR changes the behavior.

Ref: https://github.com/nvimdev/lspsaga.nvim/commit/a11b436aea63e305f9a94432e89bb26609d7a56c