### PR TITLE
fix: untrack changes in lua/user/ after installation.

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -287,6 +287,12 @@ function ring_bell {
 	[System.Console]::beep()
 }
 
+function cleanup {
+	info -Msg "Untracking user configs from git..."
+	safe_execute -WithCmd { Set-Location -Path "$env:CCDEST_DIR" }
+	@(git ls-files lua/user) | ForEach-Object {&"git" update-index --skip-worktree $_}
+}
+
 function _main {
 	if (-not $IsWindows) {
 		_abort -Msg "This install script can only execute on Windows." -Type "DeviceError"
@@ -395,6 +401,8 @@ Please make sure you have nvim v$REQUIRED_NVIM_VERSION_LEGACY installed at the v
 			Set-Content "$env:CCDEST_DIR\lua\user\settings.lua"
 		}
 	}
+
+    cleanup
 
 	info -Msg "Spawning Neovim and fetching plugins... (You'll be redirected shortly)"
 	info -Msg 'To make sqlite work with lua, manually grab the dlls from "https://www.sqlite.org/download.html" and replace'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,6 +169,12 @@ check_nvim_version() {
 	fi
 }
 
+cleanup() {
+	info "Untracking user configs from git..."
+	cd "${DEST_DIR}"
+	git ls-files -z lua/user/ | xargs -0 git update-index --skip-worktree
+}
+
 # Check if both `INTERACTIVE` and `NONINTERACTIVE` are set
 # Always use single-quoted strings with `exp` expressions
 # shellcheck disable=SC2016
@@ -291,6 +297,8 @@ if [[ "${USE_SSH}" -eq "0" ]]; then
 	info "Changing default fetching method to HTTPS..."
 	execute "perl" "-pi" "-e" "s/\[\"use_ssh\"\] \= true/\[\"use_ssh\"\] \= false/g" "${DEST_DIR}/lua/user/settings.lua"
 fi
+
+cleanup
 
 info "Spawning Neovim and fetching plugins... (You'll be redirected shortly)"
 info "NOTE: Please make sure you have a Rust Toolchain installed ${tty_underline}via \`rustup\`${tty_reset}${tty_bold}! Otherwise, unexpected things may"


### PR DESCRIPTION
Add a step after installation to make git `skip-worktree` from `user` dir.
For users already using, execute the command manually:
Windows:
```powershell
cd ~/AppData/Local/nvim
@(git ls-files lua/user) | ForEach-Object {&"git" update-index --skip-worktree $_}
```
*nix:
```shell
cd ~/.config/nvim
git ls-files -z lua/user/ | xargs -0 git update-index --skip-worktree
```
More info about `assume-unchanged` and `skip-worktree`: https://stackoverflow.com/questions/13630849/git-difference-between-assume-unchanged-and-skip-worktree

@popjdh 