### PR TITLE
fix(scripts): consider extreme cases

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -386,10 +386,7 @@ Please make sure you have nvim v$REQUIRED_NVIM_VERSION_LEGACY installed at the v
 	}
 
 	safe_execute -WithCmd { Set-Location -Path "$env:CCDEST_DIR" }
-
-	safe_execute -WithCmd { Copy-Item -Path "$env:CCDEST_DIR\lua\user_template\" -Destination "$env:CCDEST_DIR\lua\user" -Recurse }
-
-	safe_execute -WithCmd { Set-Location -Path "$env:CCDEST_DIR\lua\user" }
+	safe_execute -WithCmd { Copy-Item -Path "$env:CCDEST_DIR\lua\user_template\" -Destination "$env:CCDEST_DIR\lua\user" -Recurse -Force }
 
 	if (-not $USE_SSH) {
 		info -Msg "Changing default fetching method to HTTPS..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -286,10 +286,7 @@ EOABORT
 fi
 
 cd "${DEST_DIR}" || return
-
-execute "cp" "-r" "${DEST_DIR}/lua/user_template/" "${DEST_DIR}/lua/user"
-
-cd "${DEST_DIR}/lua/user" || return
+execute "cp" "-fRpP" "${DEST_DIR}/lua/user_template/" "${DEST_DIR}/lua/user"
 
 if [[ "${USE_SSH}" -eq "0" ]]; then
 	info "Changing default fetching method to HTTPS..."


### PR DESCRIPTION
This commit considers the following extreme cases:
* `lua/user` cannot be opened or modified.
  * **Solution:** Force overwrite w/ `-Force` or `-f`

* Recent macOS distributions shipped an implementation that is incompatible with **both** BSD and GNU `cp`.
  * **Solution:** Make it compatible (`-RpP`)

```console
     -P    No symbolic links are followed.  This is the default if the -R option is specified.

     -R    If source_file designates a directory, cp copies the directory and the entire subtree connected at that point.  If the source_file ends in a /, the contents of the directory are copied rather than the directory itself.
           This option also causes symbolic links to be copied, rather than indirected through, and for cp to create special files rather than copying them as normal files.  Created directories have the same mode as the
           corresponding source directory, unmodified by the process' umask.

           In -R mode, cp will continue copying even if errors are detected.

           Note that cp copies hard linked files as separate files.  If you need to preserve hard links, consider using tar(1), cpio(1), or pax(1) instead.

     -p    Cause cp to preserve the following attributes of each source file in the copy: modification time, access time, file flags, file mode, user ID, and group ID, as allowed by permissions.  Access Control Lists (ACLs) and
           Extended Attributes (EAs), including resource forks, will also be preserved.

           If the user ID and group ID cannot be preserved, no error message is displayed and the exit value is not altered.

           If the source file has its set-user-ID bit on and the user ID cannot be preserved, the set-user-ID bit is not preserved in the copy's permissions.  If the source file has its set-group-ID bit on and the group ID cannot
           be preserved, the set-group-ID bit is not preserved in the copy's permissions.  If the source file has both its set-user-ID and set-group-ID bits on, and either the user ID or group ID cannot be preserved, neither the
           set-user-ID nor set-group-ID bits are preserved in the copy's permissions.
```

* Since Lua's file loader takes the current directory into account (w/ the highest priority), switching to `lua/user` before spawning `nvim` for the first time may result in extremely "covert" bugs. Therefore, IMO it is best to just remove this line of instruction.