### PR TITLE
feat(null_ls_deps): add `gofumpt` and `gopls`

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -111,6 +111,8 @@ settings["null_ls_deps"] = {
 	"shfmt",
 	"stylua",
 	"vint",
+	"goimports",
+	"gofumpt",
 }
 
 -- Set the Debug Adapter Protocol (DAP) clients that will be installed and configured during bootstrap here.

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -107,12 +107,12 @@ settings["lsp_deps"] = {
 ---@type string[]
 settings["null_ls_deps"] = {
 	"clang_format",
+	"gofumpt",
+	"goimports",
 	"prettier",
 	"shfmt",
 	"stylua",
 	"vint",
-	"goimports",
-	"gofumpt",
 }
 
 -- Set the Debug Adapter Protocol (DAP) clients that will be installed and configured during bootstrap here.


### PR DESCRIPTION
- Enable `gofumpt` in `gopls` setting since it's widely used in Go community
- Import missing packages via `goimports` on save.