### PR TITLE
fix(neodim): pin to v2.0

### DIFF
--- a/lua/modules/plugins/ui.lua
+++ b/lua/modules/plugins/ui.lua
@@ -39,6 +39,7 @@ ui["nvim-lualine/lualine.nvim"] = {
 }
 ui["zbirenbaum/neodim"] = {
 	lazy = true,
+	commit = "9477da0",
 	event = "LspAttach",
 	config = require("ui.neodim"),
 }


### PR DESCRIPTION
Neodim's recent updates (specifically https://github.com/zbirenbaum/neodim/commit/2ac2f25d221bf34f70b79d0ab1d313e9826859c3) introduced/utilized some of `nvim 0.10`'s APIs, which might be a source of trouble for nvim 0.9.\*, so IMO we'd better pin `neodim` to v2.0 to avoid potential issues :D