### PR TITLE
feat: support formatting changed lines only

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -4,6 +4,11 @@ local settings = {}
 ---@type boolean
 settings["use_ssh"] = true
 
+-- Set it to true if you prefer formatting the modification region instead of the whole file
+-- NOTE: format on the whole file will also be executed if partial format is failed
+---@type boolean
+settings["format_modify"] = true
+
 -- Set it to false if there are no need to format on save.
 ---@type boolean
 settings["format_on_save"] = true

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -4,11 +4,6 @@ local settings = {}
 ---@type boolean
 settings["use_ssh"] = true
 
--- Set it to true if you prefer formatting the modification region instead of the whole file
--- NOTE: format on the whole file will also be executed if partial format is failed
----@type boolean
-settings["format_modify"] = false
-
 -- Set it to false if there are no need to format on save.
 ---@type boolean
 settings["format_on_save"] = true
@@ -16,6 +11,14 @@ settings["format_on_save"] = true
 -- Set it to false if the notification after formatting is annoying.
 ---@type boolean
 settings["format_notify"] = true
+
+-- Set it to true if you prefer formatting ONLY the *changed lines* as defined by your version control system.
+-- NOTE: This entry will only be respected if:
+--  > The buffer to be formatted is under version control (Git or Mercurial);
+--  > Any of the server attached to that buffer supports |DocumentRangeFormattingProvider| server capability.
+-- Otherwise Neovim would fall back to format the whole buffer, and a warning will be issued.
+---@type boolean
+settings["format_modifications_only"] = false
 
 -- Set it to false if you don't use copilot
 ---@type boolean

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -4,6 +4,10 @@ local settings = {}
 ---@type boolean
 settings["use_ssh"] = true
 
+-- Set it to false if you don't use copilot
+---@type boolean
+settings["use_copilot"] = true
+
 -- Set it to false if there are no need to format on save.
 ---@type boolean
 settings["format_on_save"] = true
@@ -20,9 +24,14 @@ settings["format_notify"] = true
 ---@type boolean
 settings["format_modifications_only"] = false
 
--- Set it to false if you don't use copilot
----@type boolean
-settings["use_copilot"] = true
+-- Set the format disabled directories here, files under these dirs won't be formatted on save.
+--- NOTE: Directories may contain regular expressions (grammar: vim). |regexp|
+--- NOTE: Directories are automatically normalized. |vim.fs.normalize()|
+---@type string[]
+settings["format_disabled_dirs"] = {
+	-- Example
+	"~/format_disabled_dir",
+}
 
 -- Set it to false if diagnostics virtual text is annoying.
 -- If disabled, you may browse lsp diagnostics using trouble.nvim (press `gt` to toggle it).
@@ -35,14 +44,6 @@ settings["diagnostics_virtual_text"] = true
 -- NOTE: This entry only works when `diagnostics_virtual_text` is true.
 ---@type "Error"|"Warning"|"Information"|"Hint"
 settings["diagnostics_level"] = "Hint"
-
--- Set the format disabled directories here, files under these dirs won't be formatted on save.
---- NOTE: Directories may contain regular expressions (grammar: vim). |regexp|
---- NOTE: Directories are automatically normalized. |vim.fs.normalize()|
----@type string[]
-settings["format_disabled_dirs"] = {
-	"~/format_disabled_dir",
-}
 
 -- Set the plugins to disable here.
 -- Example: "Some-User/A-Repo"

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -7,7 +7,7 @@ settings["use_ssh"] = true
 -- Set it to true if you prefer formatting the modification region instead of the whole file
 -- NOTE: format on the whole file will also be executed if partial format is failed
 ---@type boolean
-settings["format_modify"] = true
+settings["format_modify"] = false
 
 -- Set it to false if there are no need to format on save.
 ---@type boolean

--- a/lua/modules/configs/completion/formatting.lua
+++ b/lua/modules/configs/completion/formatting.lua
@@ -157,8 +157,15 @@ function M.format(opts)
 			)
 			return
 		elseif
-			format_modifications_only and require("lsp-format-modifications").format_modifications(client, bufnr)
+			format_modifications_only and require("lsp-format-modifications").format_modifications(client, bufnr).success
 		then
+			if format_notify then
+				vim.notify(
+					string.format("[LSP] Format changed lines successfully with %s!", client.name),
+					vim.log.levels.INFO,
+					{ title = "LSP Range Format Success" }
+				)
+			end
 			return
 		end
 

--- a/lua/modules/configs/completion/formatting.lua
+++ b/lua/modules/configs/completion/formatting.lua
@@ -157,7 +157,8 @@ function M.format(opts)
 			)
 			return
 		elseif
-			format_modifications_only and require("lsp-format-modifications").format_modifications(client, bufnr).success
+			format_modifications_only
+			and require("lsp-format-modifications").format_modifications(client, bufnr).success
 		then
 			if format_notify then
 				vim.notify(

--- a/lua/modules/configs/completion/formatting.lua
+++ b/lua/modules/configs/completion/formatting.lua
@@ -160,27 +160,29 @@ function M.format(opts)
 		if format_modify then
 			local lsp_fmt_modify = require("lsp-format-modifications")
 			local res = lsp_fmt_modify.format_modifications(client, bufnr)
-            -- Still try to format the whole file if partial format failed
-			if res == false then
-				local params = vim.lsp.util.make_formatting_params(opts.formatting_options)
-				local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, bufnr)
-				if result and result.result then
-					vim.lsp.util.apply_text_edits(result.result, bufnr, client.offset_encoding)
-					if format_notify then
-						vim.notify(
-							string.format("[LSP] Format successfully with %s!", client.name),
-							vim.log.levels.INFO,
-							{ title = "LSP Format Success" }
-						)
-					end
-				elseif err then
-					vim.notify(
-						string.format("[LSP][%s] %s", client.name, err),
-						vim.log.levels.ERROR,
-						{ title = "LSP Format Error" }
-					)
-				end
+			if res then
+				return
 			end
+		end
+
+		-- Still try to format the whole file if partial format failed
+		local params = vim.lsp.util.make_formatting_params(opts.formatting_options)
+		local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, bufnr)
+		if result and result.result then
+			vim.lsp.util.apply_text_edits(result.result, bufnr, client.offset_encoding)
+			if format_notify then
+				vim.notify(
+					string.format("[LSP] Format successfully with %s!", client.name),
+					vim.log.levels.INFO,
+					{ title = "LSP Format Success" }
+				)
+			end
+		elseif err then
+			vim.notify(
+				string.format("[LSP][%s] %s", client.name, err),
+				vim.log.levels.ERROR,
+				{ title = "LSP Format Error" }
+			)
 		end
 	end
 end

--- a/lua/modules/configs/completion/formatting.lua
+++ b/lua/modules/configs/completion/formatting.lua
@@ -157,6 +157,7 @@ function M.format(opts)
 			)
 			return
 		end
+
 		if format_modify then
 			local lsp_fmt_modify = require("lsp-format-modifications")
 			local res = lsp_fmt_modify.format_modifications(client, bufnr)

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -30,6 +30,10 @@ completion["simrat39/symbols-outline.nvim"] = {
 	event = "LspAttach",
 	config = require("completion.symbols-outline"),
 }
+completion["joechrisellis/lsp-format-modifications.nvim"] = {
+	lazy = true,
+	event = "LspAttach",
+}
 completion["jose-elias-alvarez/null-ls.nvim"] = {
 	lazy = true,
 	event = { "CursorHold", "CursorHoldI" },
@@ -38,10 +42,6 @@ completion["jose-elias-alvarez/null-ls.nvim"] = {
 		"nvim-lua/plenary.nvim",
 		"jay-babu/mason-null-ls.nvim",
 	},
-}
-completion["joechrisellis/lsp-format-modifications.nvim"] = {
-	lazy = true,
-	event = "LspAttach",
 }
 completion["hrsh7th/nvim-cmp"] = {
 	lazy = true,

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -39,6 +39,10 @@ completion["jose-elias-alvarez/null-ls.nvim"] = {
 		"jay-babu/mason-null-ls.nvim",
 	},
 }
+completion["joechrisellis/lsp-format-modifications.nvim"] = {
+	lazy = true,
+	event = "LspAttach",
+}
 completion["hrsh7th/nvim-cmp"] = {
 	lazy = true,
 	event = "InsertEnter",


### PR DESCRIPTION
Propose it because this requirement is common as the readme of this plugin: https://github.com/joechrisellis/lsp-format-modifications.nvim#what-problem-does-this-solve
Additionally, it's inevitable to add this function by modifying the `formatting.lua` file, which isn't what we want to see.