### PR TITLE
fix(lualine): automatically load theme for the active colorscheme

### DIFF
--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -1,6 +1,5 @@
 return function()
-	local colorscheme = vim.g.colors_name
-	local _is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
+	local is_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -10,14 +9,13 @@ return function()
 		ui = require("modules.utils.icons").get("ui", true),
 	}
 
-	local function custom_theme(is_catppuccin)
+	local function custom_theme()
+		is_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
 		vim.api.nvim_create_autocmd("ColorScheme", {
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
 			pattern = "*",
 			callback = function()
-				local colorscheme_ = vim.g.colors_name
-				local is_catppuccin_ = string.find(colorscheme_, "catppuccin") ~= nil
-				require("lualine").setup({ options = { theme = custom_theme(is_catppuccin_) } })
+				require("lualine").setup({ options = { theme = custom_theme() } })
 			end,
 		})
 
@@ -144,7 +142,7 @@ return function()
 				return "│"
 			end,
 			padding = 0,
-			color = _is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
+			color = is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
 		},
 
 		file_status = {
@@ -196,7 +194,7 @@ return function()
 				return next(available_servers) == nil and icons.misc.NoActiveLsp
 					or string.format("%s[%s]", icons.misc.LspAvailable, table.concat(available_servers, ", "))
 			end,
-			color = _is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
+			color = is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -225,7 +223,7 @@ return function()
 				end
 				return ""
 			end,
-			color = _is_catppuccin and utils.gen_hl("green", true, true) or nil,
+			color = is_catppuccin and utils.gen_hl("green", true, true) or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -240,7 +238,7 @@ return function()
 			function()
 				return icons.ui.FolderWithHeart .. utils.abbreviate_path(vim.fs.normalize(vim.fn.getcwd()))
 			end,
-			color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+			color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 		},
 
 		file_location = {
@@ -264,7 +262,7 @@ return function()
 	require("modules.utils").load_plugin("lualine", {
 		options = {
 			icons_enabled = true,
-			theme = custom_theme(_is_catppuccin),
+			theme = custom_theme(),
 			disabled_filetypes = { statusline = { "alpha" } },
 			component_separators = "",
 			section_separators = { left = "", right = "" },
@@ -289,7 +287,7 @@ return function()
 				{
 					"branch",
 					icon = icons.git_nosep.Branch,
-					color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+					color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 					cond = conditionals.has_git,
 				},
 				{
@@ -301,7 +299,7 @@ return function()
 					},
 					source = diff_source,
 					colored = false,
-					color = _is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
+					color = is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
 					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -1,6 +1,6 @@
 return function()
 	local colorscheme = vim.g.colors_name
-	local is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
+	local _is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -99,7 +99,7 @@ return function()
 				return "│"
 			end,
 			padding = 0,
-			color = is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
+			color = _is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
 		},
 
 		file_status = {
@@ -151,7 +151,7 @@ return function()
 				return next(available_servers) == nil and icons.misc.NoActiveLsp
 					or string.format("%s[%s]", icons.misc.LspAvailable, table.concat(available_servers, ", "))
 			end,
-			color = is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
+			color = _is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -180,7 +180,7 @@ return function()
 				end
 				return ""
 			end,
-			color = is_catppuccin and utils.gen_hl("green", true, true) or nil,
+			color = _is_catppuccin and utils.gen_hl("green", true, true) or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -195,7 +195,7 @@ return function()
 			function()
 				return icons.ui.FolderWithHeart .. utils.abbreviate_path(vim.fs.normalize(vim.fn.getcwd()))
 			end,
-			color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+			color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 		},
 
 		file_location = {
@@ -244,7 +244,7 @@ return function()
 				{
 					"branch",
 					icon = icons.git_nosep.Branch,
-					color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+					color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 					cond = conditionals.has_git,
 				},
 				{
@@ -256,7 +256,7 @@ return function()
 					},
 					source = diff_source,
 					colored = false,
-					color = is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
+					color = _is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
 					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -10,51 +10,6 @@ return function()
 		ui = require("modules.utils.icons").get("ui", true),
 	}
 
-	local function custom_theme(is_catppuccin)
-		vim.api.nvim_create_autocmd("ColorScheme", {
-			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
-			pattern = "*",
-			callback = function()
-				local colorscheme_ = vim.g.colors_name
-				local is_catppuccin_ = string.find(colorscheme_, "catppuccin") ~= nil
-				require("lualine").setup({ options = { theme = custom_theme(is_catppuccin_) } })
-			end,
-		})
-
-		if is_catppuccin then
-			colors = require("modules.utils").get_palette()
-			local universal_bg = require("core.settings").transparent_background and "NONE" or colors.mantle
-			return {
-				normal = {
-					a = { fg = colors.lavender, bg = colors.surface0, gui = "bold" },
-					b = { fg = colors.text, bg = universal_bg },
-					c = { fg = colors.text, bg = universal_bg },
-				},
-				command = {
-					a = { fg = colors.peach, bg = colors.surface0, gui = "bold" },
-				},
-				insert = {
-					a = { fg = colors.green, bg = colors.surface0, gui = "bold" },
-				},
-				visual = {
-					a = { fg = colors.flamingo, bg = colors.surface0, gui = "bold" },
-				},
-				terminal = {
-					a = { fg = colors.teal, bg = colors.surface0, gui = "bold" },
-				},
-				replace = {
-					a = { fg = colors.red, bg = colors.surface0, gui = "bold" },
-				},
-				inactive = {
-					a = { fg = colors.subtext0, bg = universal_bg, gui = "bold" },
-					b = { fg = colors.subtext0, bg = universal_bg },
-					c = { fg = colors.subtext0, bg = universal_bg },
-				},
-			}
-		end
-		return "auto"
-	end
-
 	local mini_sections = {
 		lualine_a = { "filetype" },
 		lualine_b = {},
@@ -264,7 +219,7 @@ return function()
 	require("modules.utils").load_plugin("lualine", {
 		options = {
 			icons_enabled = true,
-			theme = custom_theme(_is_catppuccin),
+			theme = "auto",
 			disabled_filetypes = { statusline = { "alpha" } },
 			component_separators = "",
 			section_separators = { left = "", right = "" },

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -109,18 +109,21 @@ return function()
 		---@param special_nobg boolean @Disable guibg for transparent backgrounds?
 		---@param bg string? @Background hl group
 		---@param gui string? @GUI highlight arguments
-		---@return fun():lualine_hlgrp
+		---@return fun()?:lualine_hlgrp
 		gen_hl = function(fg, gen_bg, special_nobg, bg, gui)
-			return function()
-				local guifg = colors[fg]
-				local guibg = gen_bg and require("modules.utils").hl_to_rgb("StatusLine", true, colors.mantle)
-					or colors[bg]
-				local nobg = special_nobg and require("core.settings").transparent_background
-				return {
-					fg = guifg and guifg or colors.none,
-					bg = (guibg and not nobg) and guibg or colors.none,
-					gui = gui and gui or nil,
-				}
+			if is_catppuccin then
+				return function()
+					local guifg = colors[fg]
+					local guibg = gen_bg and require("modules.utils").hl_to_rgb("StatusLine", true, colors.mantle)
+						or colors[bg]
+					local nobg = special_nobg and require("core.settings").transparent_background
+					---@diagnostic disable-next-line: redundant-return-value
+					return {
+						fg = guifg and guifg or colors.none,
+						bg = (guibg and not nobg) and guibg or colors.none,
+						gui = gui and gui or nil,
+					}
+				end
 			end
 		end,
 	}
@@ -142,7 +145,7 @@ return function()
 				return "│"
 			end,
 			padding = 0,
-			color = is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
+			color = utils.gen_hl("surface1", true, true),
 		},
 
 		file_status = {
@@ -194,7 +197,7 @@ return function()
 				return next(available_servers) == nil and icons.misc.NoActiveLsp
 					or string.format("%s[%s]", icons.misc.LspAvailable, table.concat(available_servers, ", "))
 			end,
-			color = is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
+			color = utils.gen_hl("blue", true, true, nil, "bold"),
 			cond = conditionals.has_enough_room,
 		},
 
@@ -223,7 +226,7 @@ return function()
 				end
 				return ""
 			end,
-			color = is_catppuccin and utils.gen_hl("green", true, true) or nil,
+			color = utils.gen_hl("green", true, true),
 			cond = conditionals.has_enough_room,
 		},
 
@@ -238,7 +241,7 @@ return function()
 			function()
 				return icons.ui.FolderWithHeart .. utils.abbreviate_path(vim.fs.normalize(vim.fn.getcwd()))
 			end,
-			color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+			color = utils.gen_hl("subtext0", true, true, nil, "bold"),
 		},
 
 		file_location = {
@@ -287,7 +290,7 @@ return function()
 				{
 					"branch",
 					icon = icons.git_nosep.Branch,
-					color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+					color = utils.gen_hl("subtext0", true, true, nil, "bold"),
 					cond = conditionals.has_git,
 				},
 				{
@@ -299,7 +302,7 @@ return function()
 					},
 					source = diff_source,
 					colored = false,
-					color = is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
+					color = utils.gen_hl("subtext0", true, true),
 					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -1,4 +1,6 @@
 return function()
+	local colorscheme = vim.g.colors_name
+	local _is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -8,44 +10,49 @@ return function()
 		ui = require("modules.utils.icons").get("ui", true),
 	}
 
-	local function custom_theme()
+	local function custom_theme(is_catppuccin)
 		vim.api.nvim_create_autocmd("ColorScheme", {
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
 			pattern = "*",
 			callback = function()
-				require("lualine").setup({ options = { theme = custom_theme() } })
+				local colorscheme_ = vim.g.colors_name
+				local is_catppuccin_ = string.find(colorscheme_, "catppuccin") ~= nil
+				require("lualine").setup({ options = { theme = custom_theme(is_catppuccin_) } })
 			end,
 		})
 
-		colors = require("modules.utils").get_palette()
-		local universal_bg = require("core.settings").transparent_background and "NONE" or colors.mantle
-		return {
-			normal = {
-				a = { fg = colors.lavender, bg = colors.surface0, gui = "bold" },
-				b = { fg = colors.text, bg = universal_bg },
-				c = { fg = colors.text, bg = universal_bg },
-			},
-			command = {
-				a = { fg = colors.peach, bg = colors.surface0, gui = "bold" },
-			},
-			insert = {
-				a = { fg = colors.green, bg = colors.surface0, gui = "bold" },
-			},
-			visual = {
-				a = { fg = colors.flamingo, bg = colors.surface0, gui = "bold" },
-			},
-			terminal = {
-				a = { fg = colors.teal, bg = colors.surface0, gui = "bold" },
-			},
-			replace = {
-				a = { fg = colors.red, bg = colors.surface0, gui = "bold" },
-			},
-			inactive = {
-				a = { fg = colors.subtext0, bg = universal_bg, gui = "bold" },
-				b = { fg = colors.subtext0, bg = universal_bg },
-				c = { fg = colors.subtext0, bg = universal_bg },
-			},
-		}
+		if is_catppuccin then
+			colors = require("modules.utils").get_palette()
+			local universal_bg = require("core.settings").transparent_background and "NONE" or colors.mantle
+			return {
+				normal = {
+					a = { fg = colors.lavender, bg = colors.surface0, gui = "bold" },
+					b = { fg = colors.text, bg = universal_bg },
+					c = { fg = colors.text, bg = universal_bg },
+				},
+				command = {
+					a = { fg = colors.peach, bg = colors.surface0, gui = "bold" },
+				},
+				insert = {
+					a = { fg = colors.green, bg = colors.surface0, gui = "bold" },
+				},
+				visual = {
+					a = { fg = colors.flamingo, bg = colors.surface0, gui = "bold" },
+				},
+				terminal = {
+					a = { fg = colors.teal, bg = colors.surface0, gui = "bold" },
+				},
+				replace = {
+					a = { fg = colors.red, bg = colors.surface0, gui = "bold" },
+				},
+				inactive = {
+					a = { fg = colors.subtext0, bg = universal_bg, gui = "bold" },
+					b = { fg = colors.subtext0, bg = universal_bg },
+					c = { fg = colors.subtext0, bg = universal_bg },
+				},
+			}
+		end
+		return "auto"
 	end
 
 	local mini_sections = {
@@ -137,7 +144,7 @@ return function()
 				return "│"
 			end,
 			padding = 0,
-			color = utils.gen_hl("surface1", true, true),
+			color = _is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
 		},
 
 		file_status = {
@@ -189,7 +196,7 @@ return function()
 				return next(available_servers) == nil and icons.misc.NoActiveLsp
 					or string.format("%s[%s]", icons.misc.LspAvailable, table.concat(available_servers, ", "))
 			end,
-			color = utils.gen_hl("blue", true, true, nil, "bold"),
+			color = _is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -218,7 +225,7 @@ return function()
 				end
 				return ""
 			end,
-			color = utils.gen_hl("green", true, true),
+			color = _is_catppuccin and utils.gen_hl("green", true, true) or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -233,7 +240,7 @@ return function()
 			function()
 				return icons.ui.FolderWithHeart .. utils.abbreviate_path(vim.fs.normalize(vim.fn.getcwd()))
 			end,
-			color = utils.gen_hl("subtext0", true, true, nil, "bold"),
+			color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 		},
 
 		file_location = {
@@ -257,7 +264,7 @@ return function()
 	require("modules.utils").load_plugin("lualine", {
 		options = {
 			icons_enabled = true,
-			theme = custom_theme(),
+			theme = custom_theme(_is_catppuccin),
 			disabled_filetypes = { statusline = { "alpha" } },
 			component_separators = "",
 			section_separators = { left = "", right = "" },
@@ -282,7 +289,7 @@ return function()
 				{
 					"branch",
 					icon = icons.git_nosep.Branch,
-					color = utils.gen_hl("subtext0", true, true, nil, "bold"),
+					color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 					cond = conditionals.has_git,
 				},
 				{
@@ -294,7 +301,7 @@ return function()
 					},
 					source = diff_source,
 					colored = false,
-					color = utils.gen_hl("subtext0", true, true),
+					color = _is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
 					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -10,6 +10,51 @@ return function()
 		ui = require("modules.utils.icons").get("ui", true),
 	}
 
+	local function custom_theme(is_catppuccin)
+		vim.api.nvim_create_autocmd("ColorScheme", {
+			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
+			pattern = "*",
+			callback = function()
+				local colorscheme_ = vim.g.colors_name
+				local is_catppuccin_ = string.find(colorscheme_, "catppuccin") ~= nil
+				require("lualine").setup({ options = { theme = custom_theme(is_catppuccin_) } })
+			end,
+		})
+
+		if is_catppuccin then
+			colors = require("modules.utils").get_palette()
+			local universal_bg = require("core.settings").transparent_background and "NONE" or colors.mantle
+			return {
+				normal = {
+					a = { fg = colors.lavender, bg = colors.surface0, gui = "bold" },
+					b = { fg = colors.text, bg = universal_bg },
+					c = { fg = colors.text, bg = universal_bg },
+				},
+				command = {
+					a = { fg = colors.peach, bg = colors.surface0, gui = "bold" },
+				},
+				insert = {
+					a = { fg = colors.green, bg = colors.surface0, gui = "bold" },
+				},
+				visual = {
+					a = { fg = colors.flamingo, bg = colors.surface0, gui = "bold" },
+				},
+				terminal = {
+					a = { fg = colors.teal, bg = colors.surface0, gui = "bold" },
+				},
+				replace = {
+					a = { fg = colors.red, bg = colors.surface0, gui = "bold" },
+				},
+				inactive = {
+					a = { fg = colors.subtext0, bg = universal_bg, gui = "bold" },
+					b = { fg = colors.subtext0, bg = universal_bg },
+					c = { fg = colors.subtext0, bg = universal_bg },
+				},
+			}
+		end
+		return "auto"
+	end
+
 	local mini_sections = {
 		lualine_a = { "filetype" },
 		lualine_b = {},
@@ -219,7 +264,7 @@ return function()
 	require("modules.utils").load_plugin("lualine", {
 		options = {
 			icons_enabled = true,
-			theme = "auto",
+			theme = custom_theme(_is_catppuccin),
 			disabled_filetypes = { statusline = { "alpha" } },
 			component_separators = "",
 			section_separators = { left = "", right = "" },

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -1,6 +1,6 @@
 return function()
 	local colorscheme = vim.g.colors_name
-	local _is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
+	local is_catppuccin = string.find(colorscheme, "catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -99,7 +99,7 @@ return function()
 				return "│"
 			end,
 			padding = 0,
-			color = _is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
+			color = is_catppuccin and utils.gen_hl("surface1", true, true) or nil,
 		},
 
 		file_status = {
@@ -151,7 +151,7 @@ return function()
 				return next(available_servers) == nil and icons.misc.NoActiveLsp
 					or string.format("%s[%s]", icons.misc.LspAvailable, table.concat(available_servers, ", "))
 			end,
-			color = _is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
+			color = is_catppuccin and utils.gen_hl("blue", true, true, nil, "bold") or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -180,7 +180,7 @@ return function()
 				end
 				return ""
 			end,
-			color = _is_catppuccin and utils.gen_hl("green", true, true) or nil,
+			color = is_catppuccin and utils.gen_hl("green", true, true) or nil,
 			cond = conditionals.has_enough_room,
 		},
 
@@ -195,7 +195,7 @@ return function()
 			function()
 				return icons.ui.FolderWithHeart .. utils.abbreviate_path(vim.fs.normalize(vim.fn.getcwd()))
 			end,
-			color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+			color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 		},
 
 		file_location = {
@@ -244,7 +244,7 @@ return function()
 				{
 					"branch",
 					icon = icons.git_nosep.Branch,
-					color = _is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
+					color = is_catppuccin and utils.gen_hl("subtext0", true, true, nil, "bold") or nil,
 					cond = conditionals.has_git,
 				},
 				{
@@ -256,7 +256,7 @@ return function()
 					},
 					source = diff_source,
 					colored = false,
-					color = _is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
+					color = is_catppuccin and utils.gen_hl("subtext0", true, true) or nil,
 					cond = conditionals.has_git,
 					padding = { right = 1 },
 				},

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -1,5 +1,5 @@
 return function()
-	local is_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+	local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -10,16 +10,16 @@ return function()
 	}
 
 	local function custom_theme()
-		is_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
 		vim.api.nvim_create_autocmd("ColorScheme", {
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
 			pattern = "*",
 			callback = function()
+				has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
 				require("lualine").setup({ options = { theme = custom_theme() } })
 			end,
 		})
 
-		if is_catppuccin then
+		if has_catppuccin then
 			colors = require("modules.utils").get_palette()
 			local universal_bg = require("core.settings").transparent_background and "NONE" or colors.mantle
 			return {
@@ -49,8 +49,9 @@ return function()
 					c = { fg = colors.subtext0, bg = universal_bg },
 				},
 			}
+		else
+			return "auto"
 		end
-		return "auto"
 	end
 
 	local mini_sections = {
@@ -109,21 +110,23 @@ return function()
 		---@param special_nobg boolean @Disable guibg for transparent backgrounds?
 		---@param bg string? @Background hl group
 		---@param gui string? @GUI highlight arguments
-		---@return fun()?:lualine_hlgrp
+		---@return nil|fun():lualine_hlgrp
 		gen_hl = function(fg, gen_bg, special_nobg, bg, gui)
-			if is_catppuccin then
+			if has_catppuccin then
 				return function()
 					local guifg = colors[fg]
 					local guibg = gen_bg and require("modules.utils").hl_to_rgb("StatusLine", true, colors.mantle)
 						or colors[bg]
 					local nobg = special_nobg and require("core.settings").transparent_background
-					---@diagnostic disable-next-line: redundant-return-value
 					return {
 						fg = guifg and guifg or colors.none,
 						bg = (guibg and not nobg) and guibg or colors.none,
 						gui = gui and gui or nil,
 					}
 				end
+			else
+				-- Return `nil` if the theme is user-defined
+				return nil
 			end
 		end,
 	}


### PR DESCRIPTION
By utilizing "auto" theme as mentioned [here](https://github.com/nvim-lualine/lualine.nvim/blob/master/THEMES.md#auto), this PR corrects the appearance of `lualine` when using other colorschemes.
Of course, users using `catppuccin` won't be influenced.