### PR TITLE
feat: customized `neovide` and `gui` config

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -1,4 +1,5 @@
 local global = require("core.global")
+local settings = require("core.settings")
 
 -- Create cache dir and data dirs
 local createdir = function()
@@ -77,18 +78,16 @@ local leader_map = function()
 	vim.api.nvim_set_keymap("x", " ", "", { noremap = true })
 end
 
+local gui_config = function()
+	local config = settings.gui_config
+	vim.api.nvim_set_option_value("guifont", config.font_name .. ":h" .. config.font_size, {})
+end
+
 local neovide_config = function()
-	vim.api.nvim_set_option_value("guifont", "JetBrainsMono Nerd Font:h15", {})
-	vim.g.neovide_refresh_rate = 120
-	vim.g.neovide_cursor_vfx_mode = "railgun"
-	vim.g.neovide_no_idle = true
-	vim.g.neovide_cursor_animation_length = 0.03
-	vim.g.neovide_cursor_trail_length = 0.05
-	vim.g.neovide_cursor_antialiasing = true
-	vim.g.neovide_cursor_vfx_opacity = 200.0
-	vim.g.neovide_cursor_vfx_particle_lifetime = 1.2
-	vim.g.neovide_cursor_vfx_particle_speed = 20.0
-	vim.g.neovide_cursor_vfx_particle_density = 5.0
+	local config = settings.neovide_config
+	for key, value in ipairs(config) do
+		vim.g["neovide_" .. key] = value
+	end
 end
 
 local clipboard_config = function()
@@ -148,6 +147,7 @@ local load_core = function()
 	disable_distribution_plugins()
 	leader_map()
 
+	gui_config()
 	neovide_config()
 	clipboard_config()
 	shell_config()
@@ -158,8 +158,8 @@ local load_core = function()
 	require("core.event")
 	require("core.pack")
 
-	local colorscheme = require("core.settings").colorscheme
-	local background = require("core.settings").background
+	local colorscheme = settings.colorscheme
+	local background = settings.background
 	vim.api.nvim_command("set background=" .. background)
 	vim.api.nvim_command("colorscheme " .. colorscheme)
 end

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -161,4 +161,22 @@ settings["treesitter_deps"] = {
 	"yaml",
 }
 
+settings["gui_config"] = {
+	font_name = "JetBrainsMono Nerd Font",
+	font_size = 12,
+}
+
+settings["neovide_config"] = {
+	refresh_rate = 120,
+	cursor_vfx_mode = "railgun",
+	no_idle = true,
+	cursor_animation_length = 0.03,
+	cursor_trail_length = 0.05,
+	cursor_antialiasing = true,
+	cursor_vfx_opacity = 200.0,
+	cursor_vfx_particle_lifetime = 1.2,
+	cursor_vfx_particle_speed = 20.0,
+	cursor_vfx_particle_density = 5.0,
+}
+
 return require("modules.utils").extend_config(settings, "user.settings")

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -161,11 +161,13 @@ settings["treesitter_deps"] = {
 	"yaml",
 }
 
+-- Settings for the neovim-guis like `neovide`, `neovim-qt`, etc.
 settings["gui_config"] = {
 	font_name = "JetBrainsMono Nerd Font",
 	font_size = 12,
 }
 
+-- Settings for `neovide`
 settings["neovide_config"] = {
 	refresh_rate = 120,
 	cursor_vfx_mode = "railgun",

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -162,12 +162,14 @@ settings["treesitter_deps"] = {
 }
 
 -- Settings for the neovim-guis like `neovide`, `neovim-qt`, etc.
+-- NOTE: Only supports the options listed below.
 settings["gui_config"] = {
 	font_name = "JetBrainsMono Nerd Font",
 	font_size = 12,
 }
 
--- Settings for `neovide`
+-- Settings for `neovide`.
+-- NOTE: Get the full configurable options: https://neovide.dev/configuration.html
 settings["neovide_config"] = {
 	refresh_rate = 120,
 	cursor_vfx_mode = "railgun",


### PR DESCRIPTION
This PR did two things.

+ Separate the config of `guifont` and `neovide`.
+ Add two settings entrys in `lua/core/settings.lua` named as `gui_config` and `neovide_config`.

This PR is backward-compatible.