### PR TITLE
fix: auto apply formatter args set in `user/configs/formatters`.

### DIFF
--- a/lua/modules/configs/completion/null-ls.lua
+++ b/lua/modules/configs/completion/null-ls.lua
@@ -2,12 +2,26 @@ return function()
 	local null_ls = require("null-ls")
 	local btns = null_ls.builtins
 
+	---Return formatter args required by `extra_args`
+	---@param formatter_name string
+	---@return table|nil
+	local function formatter_args(formatter_name)
+		local ok, args = pcall(require, "user.configs.formatters." .. formatter_name)
+		if not ok then
+			ok, args = pcall(require, "completion.formatters." .. formatter_name)
+		end
+		if not ok then
+			args = nil
+		end
+		return args
+	end
+
 	-- Please set additional flags for the supported servers here
 	-- Don't specify any config here if you are using the default one.
 	local sources = {
 		btns.formatting.clang_format.with({
 			filetypes = { "c", "cpp" },
-			extra_args = require("completion.formatters.clang_format"),
+			extra_args = formatter_args("clang_format"),
 		}),
 		btns.formatting.prettier.with({
 			filetypes = {

--- a/lua/modules/configs/completion/null-ls.lua
+++ b/lua/modules/configs/completion/null-ls.lua
@@ -8,10 +8,7 @@ return function()
 	local function formatter_args(formatter_name)
 		local ok, args = pcall(require, "user.configs.formatters." .. formatter_name)
 		if not ok then
-			ok, args = pcall(require, "completion.formatters." .. formatter_name)
-		end
-		if not ok then
-			args = nil
+			args = require("completion.formatters." .. formatter_name)
 		end
 		return args
 	end


### PR DESCRIPTION
This PR supports applying formatter args set in `user/configs/formatters`. The related wiki will be updated after merging.