### PR TITLE
fix(neovide): neovide is not set up correctly because of `ipairs`

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -83,7 +83,7 @@ local gui_config = function()
 end
 
 local neovide_config = function()
-	for name, config in ipairs(settings.neovide_config) do
+	for name, config in pairs(settings.neovide_config) do
 		vim.g["neovide_" .. name] = config
 	end
 end


### PR DESCRIPTION
since the numeric keys are ignored as whole in `iparis` iteration, configurations in `neovide_config` actually aren't set to neovide, after switching `ipairs` to `pairs`, configurations are set properly.