### PR TITLE
feat(treesitter): use ts-indent and disable legacy syntax engine

### DIFF
--- a/lua/modules/configs/editor/treesitter.lua
+++ b/lua/modules/configs/editor/treesitter.lua
@@ -16,7 +16,7 @@ return vim.schedule_wrap(function()
 				local ok, is_large_file = pcall(vim.api.nvim_buf_get_var, bufnr, "bigfile_disable_treesitter")
 				return ok and is_large_file
 			end,
-			additional_vim_regex_highlighting = { "c", "cpp" },
+			additional_vim_regex_highlighting = false,
 		},
 		textobjects = {
 			select = {
@@ -50,6 +50,7 @@ return vim.schedule_wrap(function()
 			},
 		},
 		context_commentstring = { enable = true, enable_autocmd = false },
+		indent = { enable = true },
 		matchup = { enable = true },
 	}, false, require("nvim-treesitter.configs").setup)
 	require("nvim-treesitter.install").prefer_git = true


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter/commit/f53e6e82df8efb17b9b04d2f6d5ad64755786b7e fixed the last dangling syntax issue in C/C++, So IMO we can now completely switch to treesitter-based highlight (and indent) lol