### PR TITLE
perf(ts-context): limit `max_lines` to 3

### DIFF
--- a/lua/modules/configs/editor/ts-context.lua
+++ b/lua/modules/configs/editor/ts-context.lua
@@ -1,7 +1,7 @@
 return function()
 	require("modules.utils").load_plugin("treesitter-context", {
 		enable = true,
-		max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
+		max_lines = 3, -- How many lines the window should span. Values <= 0 mean no limit.
 		min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
 		line_numbers = true,
 		multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line


### PR DESCRIPTION
It appears that when navigating through syntax trees of great intricacy, `ts-context` would expend an excessive amount of time collecting _(and rendering)_ all "candidate nodes" from here to the root of the tree when the cursor goes deep into a particular "branch", given our current settings. This PR limited `max_lines` to 3, as IMO we seldom need hierarchical information about nodes that are _too_ distant from the current one in practice, and `3` is also the optimal value I've found in recent trials that strikes a balance between the amount of practical information and performance penalties lol