### PR TITLE
feat(plugins): add `nvim-bqf`

### DIFF
--- a/lua/modules/configs/lang/bqf.lua
+++ b/lua/modules/configs/lang/bqf.lua
@@ -1,0 +1,9 @@
+return function()
+	require("modules.utils").load_plugin("bqf", {
+		preview = {
+			border = "single",
+			wrap = true,
+			winblend = 0,
+		},
+	})
+end

--- a/lua/modules/plugins/lang.lua
+++ b/lua/modules/plugins/lang.lua
@@ -1,5 +1,13 @@
 local lang = {}
 
+lang["kevinhwang91/nvim-bqf"] = {
+	lazy = true,
+	ft = "qf",
+	config = require("lang.bqf"),
+	dependencies = {
+		{ "junegunn/fzf", build = ":call fzf#install()" },
+	},
+}
 lang["fatih/vim-go"] = {
 	lazy = true,
 	ft = "go",


### PR DESCRIPTION
IMO we could think about bringing `nvim-bqf` back. Not only does it make nvim's quickfix mode a breeze to use, but it also sidesteps some of the issues we had before, like #981. Plus, it's a plugin that loads on demand, so it shouldn't cause any side effects 😄