### PR TITLE
feat(script): skip dependency installation by default

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -242,7 +242,7 @@ function confirm_dep_inst ([Parameter(Mandatory = $True)][ValidateNotNullOrEmpty
 		$_opt_yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes","Will install $PkgName dependencies"
 		$_opt_no = New-Object System.Management.Automation.Host.ChoiceDescription "&No","Will SKIP installing $PkgName dependencies"
 
-		$USR_CHOICE = $Host.ui.PromptForChoice($_title,$_message,[System.Management.Automation.Host.ChoiceDescription[]]($_opt_yes,$_opt_no),0)
+		$USR_CHOICE = $Host.ui.PromptForChoice($_title,$_message,[System.Management.Automation.Host.ChoiceDescription[]]($_opt_yes,$_opt_no),1)
 		if ($USR_CHOICE -eq 0) {
 			return $True
 		} else {


### PR DESCRIPTION
IMO the default choice for dependency installation in `install.ps1` is a bit misleading (see Discussion #1106). afaik most users won't even "visit" the dynamic provider feature of Neovim, and those who know what they're doing can still continue with the dependency installation by typing `Y/y`. So I think a more reasonable default should be `N` (i.e. skipping provider installation altogether.)