### PR TITLE
fix(bufferline): use `BufDel %d` instead of `bdelete! %d`

### DIFF
--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -4,8 +4,8 @@ return function()
 	local opts = {
 		options = {
 			number = nil,
-			close_command = "BufDel",
-			right_mouse_command = "BufDel",
+			close_command = "BufDel %d",
+			right_mouse_command = "BufDel %d",
 			modified_icon = icons.ui.Modified,
 			buffer_close_icon = icons.ui.Close,
 			left_trunc_marker = icons.ui.Left,

--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -4,6 +4,8 @@ return function()
 	local opts = {
 		options = {
 			number = nil,
+			close_command = "BufDel",
+			right_mouse_command = "BufDel",
 			modified_icon = icons.ui.Modified,
 			buffer_close_icon = icons.ui.Close,
 			left_trunc_marker = icons.ui.Left,


### PR DESCRIPTION
When I use the close button on bufferline, it often exits abnormally.
After using BufDel %d instead of bdelete! %d, this situation no longer occurs.