### PR TITLE
fix(bufferline): avoid unnecessary user interaction

### DIFF
--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -4,8 +4,8 @@ return function()
 	local opts = {
 		options = {
 			number = nil,
-			close_command = "BufDel %d",
-			right_mouse_command = "BufDel %d",
+			close_command = "BufDel! %d",
+			right_mouse_command = "BufDel! %d",
 			modified_icon = icons.ui.Modified,
 			buffer_close_icon = icons.ui.Close,
 			left_trunc_marker = icons.ui.Left,


### PR DESCRIPTION
This is a follow-up fix for #1136. It prevents `bufferline` from tripping over errors thrown by `nvim-bufdel`, and is also keeping up with the upstream close command (`bdelete!`)