### PR TITLE
fix(rust): respect user configs

### DIFF
--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -28,6 +28,23 @@ M.setup = function()
 	---A handler to setup all servers defined under `completion/servers/*.lua`
 	---@param lsp_name string
 	local function mason_lsp_handler(lsp_name)
+		-- rust_analyzer is configured using mrcjkb/rustaceanvim
+		-- warn users if they have set it up manually
+		if lsp_name == "rust_analyzer" then
+			local config_exist = pcall(require, "completion.servers." .. lsp_name)
+			if config_exist then
+				vim.notify(
+					[[
+`rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,
+please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` directory and configure
+`rust_analyzer` using the appropriate init options provided by `rustaceanvim` instead.]],
+					vim.log.levels.WARN,
+					{ title = "nvim-lspconfig" }
+				)
+			end
+			return
+		end
+
 		local ok, custom_handler = pcall(require, "user.configs.lsp-servers." .. lsp_name)
 		-- Use preset if there is no user definition
 		if not ok then

--- a/lua/modules/configs/lang/rust.lua
+++ b/lua/modules/configs/lang/rust.lua
@@ -1,12 +1,8 @@
 return function()
 	vim.g.rustaceanvim = {
-		-- DAP configuration
-		dap = {
-			adapter = {
-				type = "executable",
-				command = "lldb-vscode",
-				name = "rt_lldb",
-			},
-		},
+		-- Disable automatic DAP configuration to avoid conflicts with previous user configs
+		dap = { adapter = false, configuration = false },
 	}
+
+	require("modules.utils").load_plugin("rustaceanvim", nil, true)
 end


### PR DESCRIPTION
This PR does three things:

- Allows users to overwrite the init options of `rustaceanvim` thru their custom configs;

- It gives a heads-up to users that if they're still manually setting up `rust_analyzer`, [this will result in two identical servers being spawned](https://github.com/ayamir/nvimdots/pull/1140#issuecomment-1881190708);

- DAP-related settings are disabled by default to avoid potential conflicts with previous user configurations. IMO since we already have [configs for `codelldb`](https://github.com/ayamir/nvimdots/blob/f2cf03b254c21a69d3654c2c05014cd411ac14e2/lua/modules/configs/tool/dap/clients/codelldb.lua#L46) that can be used, users can simply tweak those configs on their own. But I'm not 2 sure about this, as I personally don't do much rust development. What do u guys think @ClSlaid @CharlesChiuGit @ayamir?