### PR TITLE
fix(keymap): never map `<leader>` to `<Nop>`

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -75,8 +75,11 @@ end
 
 local leader_map = function()
 	vim.g.mapleader = " "
-	vim.api.nvim_set_keymap("n", " ", "", { noremap = true })
-	vim.api.nvim_set_keymap("x", " ", "", { noremap = true })
+	-- NOTE:
+	--  > Uncomment the following if you're using a <leader> other than <Space>, and you wish
+	--  > to disable advancing one character by pressing <Space> in normal/visual mode.
+	-- vim.api.nvim_set_keymap("n", " ", "", { noremap = true })
+	-- vim.api.nvim_set_keymap("x", " ", "", { noremap = true })
 end
 
 local gui_config = function()


### PR DESCRIPTION
See https://github.com/ayamir/nvimdots/issues/1141#issuecomment-1885885998.