### PR TITLE
fix(telescope): remove telescope folding hack since PR with fix has been merged upstream

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -63,16 +63,6 @@ vim.api.nvim_create_autocmd("FileType", {
 	end,
 })
 
--- Fix fold issue of files opened by telescope
-vim.api.nvim_create_autocmd("BufRead", {
-	callback = function()
-		vim.api.nvim_create_autocmd("BufWinEnter", {
-			once = true,
-			command = "normal! zx",
-		})
-	end,
-})
-
 function autocmd.load_autocmds()
 	local definitions = {
 		lazy = {},


### PR DESCRIPTION
see
https://github.com/LazyVim/LazyVim/commit/02bc41412a14c1c0bb823421ef82ff5596f42571
https://github.com/nvim-telescope/telescope.nvim/issues/699
https://github.com/nvim-telescope/telescope.nvim/pull/2726