### PR TITLE
fix(scrollview): omit the `scrollview_` prefix

### DIFF
--- a/lua/modules/configs/ui/scrollview.lua
+++ b/lua/modules/configs/ui/scrollview.lua
@@ -2,7 +2,7 @@ return function()
 	local icons = { diagnostics = require("modules.utils.icons").get("diagnostics", true) }
 
 	require("modules.utils").load_plugin("scrollview", {
-		scrollview_mode = "virtual",
+		mode = "virtual",
 		excluded_filetypes = { "NvimTree", "terminal", "nofile", "aerial" },
 		winblend = 0,
 		signs_on_startup = { "diagnostics", "folds", "marks", "search", "spell" },


### PR DESCRIPTION
https://github.com/dstein64/nvim-scrollview?tab=readme-ov-file#lua-example
A Lua `setup()` function is provided for convenience, to set globally scoped options (the 'scrollview_' prefix is omitted).