### PR TITLE
feat: make `lazy` option configurable.

### DIFF
--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -60,6 +60,21 @@ function Lazy:load_plugins()
 	for _, name in ipairs(settings.disabled_plugins) do
 		self.modules[#self.modules + 1] = { name, enabled = false }
 	end
+
+	for _, config in ipairs(settings.lazy_config) do
+		if type(config) == "table" then
+			local plugin_name = ""
+			for key, value in pairs(config) do
+				if type(key) == "number" then
+					plugin_name = value
+				else
+					if plugin_name ~= "" then
+						self.modules[#self.modules + 1] = { plugin_name, lazy = value }
+					end
+				end
+			end
+		end
+	end
 end
 
 function Lazy:load_lazy()

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -50,6 +50,11 @@ settings["diagnostics_level"] = "Hint"
 ---@type string[]
 settings["disabled_plugins"] = {}
 
+-- Set the plugins lazy config here
+-- Example: { "olimorris/persisted.nvim", lazy = false }
+---@type table
+settings["lazy_config"] = {}
+
 -- Set it to false if you don't use nvim to open big files.
 ---@type boolean
 settings["load_big_files_faster"] = true

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -50,7 +50,7 @@ settings["diagnostics_level"] = "Hint"
 ---@type string[]
 settings["disabled_plugins"] = {}
 
--- Set the plugins lazy config here
+-- Set whether the plugin lazy load
 -- Example: { "olimorris/persisted.nvim", lazy = false }
 ---@type table
 settings["lazy_config"] = {}


### PR DESCRIPTION
Previous implementation doesn't consider configurable lazy options like `lazy = false`, which can't make some plugins function works normally such as `autoload = true` for `persisted.nvim`. I only make this option configurable because the modification of other options like `event`, `cmd`, `cond`... etc, should be done by ourselves rather than users.