### PR TITLE
feat!: pin `none-ls` until upstream deprecation is finished

### DIFF
--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -36,6 +36,7 @@ completion["joechrisellis/lsp-format-modifications.nvim"] = {
 }
 completion["nvimtools/none-ls.nvim"] = {
 	lazy = true,
+	commit = "f81edad87bc6c1a4e675e8e97b22a62939ad4ade",
 	event = { "CursorHold", "CursorHoldI" },
 	config = require("completion.null-ls"),
 	dependencies = {


### PR DESCRIPTION
cc #1183 