### PR TITLE
feat(ui): enable global statusline, disable all extension.

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -43,7 +43,7 @@ local function load_options()
 		incsearch = true,
 		infercase = true,
 		jumpoptions = "stack",
-		laststatus = 2,
+		laststatus = 3,
 		linebreak = true,
 		list = true,
 		listchars = "tab:»·,nbsp:+,trail:·,extends:→,precedes:←",

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -54,23 +54,6 @@ return function()
 		end
 	end
 
-	local mini_sections = {
-		lualine_a = { "filetype" },
-		lualine_b = {},
-		lualine_c = {},
-		lualine_x = {},
-		lualine_y = {},
-		lualine_z = {},
-	}
-	local outline = {
-		sections = mini_sections,
-		filetypes = { "aerial" },
-	}
-	local diffview = {
-		sections = mini_sections,
-		filetypes = { "DiffviewFiles" },
-	}
-
 	local conditionals = {
 		has_enough_room = function()
 			return vim.o.columns > 100
@@ -358,14 +341,6 @@ return function()
 			lualine_z = {},
 		},
 		tabline = {},
-		extensions = {
-			"quickfix",
-			"nvim-tree",
-			"nvim-dap-ui",
-			"toggleterm",
-			"fugitive",
-			outline,
-			diffview,
-		},
+		extensions = {},
 	})
 end


### PR DESCRIPTION
Global statusline is more friendly for multiple window splits.
Besides, I disabled all extension which looks not suitable for global statusline.

![image](https://github.com/ayamir/nvimdots/assets/61657399/54f4dc82-ef14-444c-9f06-61274cc916ed)
