### PR TITLE
chore: cleanup and minor syntax improvements

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _toggle_lazygit _command_panel _flash_esc_or_noh _debugging --max-line-length 150 --no-config
+          args: . --std luajit --globals vim _toggle_lazygit _buf_vtext _command_panel _flash_esc_or_noh _debugging --max-line-length 150 --no-config

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Branch info:
 
 | Branch | Supported neovim version |
 | :----: | :----------------------: |
-|  0.10  |    nvim 0.10 nightly     |
 |  main  |     nvim 0.9 stable      |
+|  0.10  |    nvim 0.10 nightly     |
 |  0.8   |         nvim 0.8         |
 |  0.7   |         nvim 0.7         |
 

--- a/lua/keymap/helpers.lua
+++ b/lua/keymap/helpers.lua
@@ -39,8 +39,7 @@ _G._toggle_lazygit = function()
 	end
 end
 
--- TODO: Update this function to use `vim.region()`.
--- TODO: Change `vim.region() [deprecated in nvim 0.10]` to `vim.getregion()` when v0.10 is released.
+-- TODO: Update this function to use `vim.getregion()` when v0.10 is released.
 _G._buf_vtext = function()
 	local a_orig = vim.fn.getreg("a")
 	local mode = vim.fn.mode()

--- a/lua/keymap/helpers.lua
+++ b/lua/keymap/helpers.lua
@@ -39,6 +39,8 @@ _G._toggle_lazygit = function()
 	end
 end
 
+-- TODO: Update this function to use `vim.region()`.
+-- TODO: Change `vim.region() [deprecated in nvim 0.10]` to `vim.getregion()` when v0.10 is released.
 _G._buf_vtext = function()
 	local a_orig = vim.fn.getreg("a")
 	local mode = vim.fn.mode()

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -133,7 +133,7 @@ local plug_map = {
 	["n|<leader>fb"] = map_cu("Telescope buffers"):with_noremap():with_silent():with_desc("find: Buffer opened"),
 	["n|<leader>fs"] = map_cu("Telescope grep_string"):with_noremap():with_silent():with_desc("find: Current word"),
 	["v|<leader>fs"] = map_callback(function()
-			require("telescope.builtin").grep_string({ search = _buf_vtext() }) -- luacheck: ignore
+			require("telescope.builtin").grep_string({ search = _buf_vtext() })
 		end)
 		:with_noremap()
 		:with_silent()

--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -66,26 +66,6 @@ return function()
 		}
 
 	local cmp = require("cmp")
-	cmp.setup.cmdline("/", {
-		mapping = cmp.mapping.preset.cmdline(),
-		sources = {
-			{ name = "buffer" },
-		},
-	})
-	cmp.setup.cmdline(":", {
-		mapping = cmp.mapping.preset.cmdline(),
-		sources = cmp.config.sources({
-			{ name = "path" },
-		}, {
-			{
-				name = "cmdline",
-				option = {
-					ignore_cmds = { "Man", "!" },
-				},
-			},
-		}),
-	})
-
 	require("modules.utils").load_plugin("cmp", {
 		preselect = cmp.PreselectMode.Item,
 		window = {

--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -85,7 +85,7 @@ return function()
 			},
 		}),
 	})
-	local luasnip = require("luasnip")
+
 	require("modules.utils").load_plugin("cmp", {
 		preselect = cmp.PreselectMode.Item,
 		window = {
@@ -157,8 +157,8 @@ return function()
 			["<Tab>"] = cmp.mapping(function(fallback)
 				if cmp.visible() then
 					cmp.select_next_item()
-				elseif luasnip.expand_or_locally_jumpable() then
-					luasnip.expand_or_jump()
+				elseif require("luasnip").expand_or_locally_jumpable() then
+					require("luasnip").expand_or_jump()
 				else
 					fallback()
 				end

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -2,15 +2,9 @@
 -- https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
 return function()
 	local dap = require("dap")
-	local is_windows = require("core.global").is_windows
-	local data_dir = require("core.global").data_dir
-	local python = is_windows and data_dir .. "../mason/packages/debugpy/venv/Scripts/pythonw.exe"
-		or data_dir .. "../mason/packages/debugpy/venv/bin/python"
 	local utils = require("modules.utils.dap")
-
-	local function is_empty(s)
-		return s == nil or s == ""
-	end
+	local is_windows = require("core.global").is_windows
+	local debugpy_root = require("mason-registry").get_package("debugpy"):get_install_path()
 
 	dap.adapters.python = function(callback, config)
 		if config.request == "attach" then
@@ -25,7 +19,8 @@ return function()
 		else
 			callback({
 				type = "executable",
-				command = python,
+				command = is_windows and debugpy_root .. "/venv/Scripts/pythonw.exe"
+					or debugpy_root .. "/venv/bin/python",
 				args = { "-m", "debugpy.adapter" },
 				options = { source_filetype = "python" },
 			})
@@ -41,9 +36,9 @@ return function()
 			console = "integratedTerminal",
 			program = utils.input_file_path(),
 			pythonPath = function()
-				if not is_empty(vim.env.CONDA_PREFIX) then
-					return is_windows and vim.env.CONDA_PREFIX .. "/Scripts/pythonw.exe"
-						or vim.env.CONDA_PREFIX .. "/bin/python"
+				local venv = vim.env.CONDA_PREFIX
+				if venv then
+					return is_windows and venv .. "/Scripts/pythonw.exe" or venv .. "/bin/python"
 				else
 					return is_windows and "pythonw.exe" or "python3"
 				end
@@ -58,25 +53,18 @@ return function()
 			console = "integratedTerminal",
 			program = utils.input_file_path(),
 			pythonPath = function()
+				-- Prefer the venv that is defined by the designated environment variable.
 				local cwd, venv = vim.fn.getcwd(), os.getenv("VIRTUAL_ENV")
-				if
-					venv
-					and (
-						vim.fn.executable(venv .. "/bin/python") == 1
-						or vim.fn.executable(venv .. "/Scripts/pythonw.exe") == 1
-					)
-				then
-					return is_windows and venv .. "/Scripts/pythonw.exe" or venv .. "/bin/python"
-				elseif
-					(vim.fn.executable(cwd .. "/venv/bin/python") == 1)
-					or (vim.fn.executable(cwd .. "/venv/Scripts/pythonw.exe") == 1)
-				then
-					return is_windows and cwd .. "/venv/Scripts/pythonw.exe" or cwd .. "/venv/bin/python"
-				elseif
-					(vim.fn.executable(cwd .. "/.venv/bin/python") == 1)
-					or (vim.fn.executable(cwd .. "/.venv/Scripts/pythonw.exe") == 1)
-				then
-					return is_windows and cwd .. "/.venv/Scripts/pythonw.exe" or cwd .. "/.venv/bin/python"
+				local python = venv and (is_windows and venv .. "/Scripts/pythonw.exe" or venv .. "/bin/python") or ""
+				if vim.fn.executable(python) == 1 then
+					return python
+				end
+
+				-- Otherwise, fall back to check if there are any local venvs available.
+				venv = vim.fn.isdirectory(cwd .. "/venv") == 1 and cwd .. "/venv" or cwd .. "/.venv"
+				python = is_windows and venv .. "/Scripts/pythonw.exe" or venv .. "/bin/python"
+				if vim.fn.executable(python) == 1 then
+					return python
 				else
 					return is_windows and "pythonw.exe" or "python3"
 				end

--- a/lua/modules/configs/tool/telescope.lua
+++ b/lua/modules/configs/tool/telescope.lua
@@ -58,7 +58,6 @@ return function()
 				case_mode = "smart_case",
 			},
 			frecency = {
-				use_sqlite = false,
 				show_scores = true,
 				show_unindexed = true,
 				ignore_patterns = { "*.git/*", "*/tmp/*" },

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,7 +8,6 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = "Stop" # Exit when command fails
 
 # global-scope vars
-$REQUIRED_NVIM_VERSION_NIGHTLY = [version]'0.10'
 $REQUIRED_NVIM_VERSION = [version]'0.9.0'
 $REQUIRED_NVIM_VERSION_LEGACY = [version]'0.8.0'
 $USE_SSH = $True
@@ -21,7 +20,6 @@ $installer_pkg_matrix = @{ "NodeJS" = "npm"; "Python" = "pip"; "Ruby" = "gem" }
 # env vars
 $env:XDG_CONFIG_HOME ??= $env:LOCALAPPDATA
 $env:CCPACK_MGR ??= 'unknown'
-$env:CCLONE_BRANCH_NIGHTLY ??= '0.10'
 $env:CCLONE_BRANCH ??= 'main'
 $env:CCLONE_BRANCH_LEGACY ??= '0.8'
 $env:CCLONE_ATTR ??= 'undef'
@@ -285,15 +283,13 @@ function check_nvim_version ([Parameter(Mandatory = $True)][ValidateNotNullOrEmp
 	return ($nvim_version -ge $RequiredVersionMin)
 }
 
-function clone_by_https_or_ssh ([Parameter(Mandatory = $True)][ValidateNotNullOrEmpty()] [string]$CloneUrl) {
-	if ((check_nvim_version -RequiredVersionMin $REQUIRED_NVIM_VERSION_NIGHTLY)) {
-		safe_execute -WithCmd { git clone --progress -b "$env:CCLONE_BRANCH_NIGHTLY" "$env:CCLONE_ATTR" $CloneUrl "$env:CCDEST_DIR" }
-	} elseif ((check_nvim_version -RequiredVersionMin $REQUIRED_NVIM_VERSION)) {
-		safe_execute -WithCmd { git clone --progress -b "$env:CCLONE_BRANCH" "$env:CCLONE_ATTR" $CloneUrl "$env:CCDEST_DIR" }
+function clone_repo ([Parameter(Mandatory = $True)][ValidateNotNullOrEmpty()] [string]$WithURL) {
+	if ((check_nvim_version -RequiredVersionMin $REQUIRED_NVIM_VERSION)) {
+		safe_execute -WithCmd { git clone --progress -b "$env:CCLONE_BRANCH" "$env:CCLONE_ATTR" $WithURL "$env:CCDEST_DIR" }
 	} elseif ((check_nvim_version -RequiredVersionMin $REQUIRED_NVIM_VERSION_LEGACY)) {
 		warn -Msg "You have outdated Nvim installed (< $REQUIRED_NVIM_VERSION)."
 		info -Msg "Automatically redirecting you to the latest compatible version..."
-		safe_execute -WithCmd { git clone --progress -b "$env:CCLONE_BRANCH_LEGACY" "$env:CCLONE_ATTR" $CloneUrl "$env:CCDEST_DIR" }
+		safe_execute -WithCmd { git clone --progress -b "$env:CCLONE_BRANCH_LEGACY" "$env:CCLONE_ATTR" $WithURL "$env:CCDEST_DIR" }
 	} else {
 		warn -Msg "You have outdated Nvim installed (< $REQUIRED_NVIM_VERSION_LEGACY)."
 		_abort -Msg "This Neovim distribution is no longer supported." -Type "NotImplemented" -Info_msg @"
@@ -375,9 +371,9 @@ You must install Git before installing this Nvim config. See:
 	info -Msg "Fetching in progress..."
 
 	if ($USE_SSH) {
-		clone_by_https_or_ssh 'git@github.com:ayamir/nvimdots.git'
+		clone_repo -WithURL 'git@github.com:ayamir/nvimdots.git'
 	} else {
-		clone_by_https_or_ssh 'https://github.com/ayamir/nvimdots.git'
+		clone_repo -WithURL 'https://github.com/ayamir/nvimdots.git'
 	}
 
 	safe_execute -WithCmd { Set-Location -Path "$env:CCDEST_DIR" }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,6 @@ set -u
 DEST_DIR="${HOME}/.config/nvim"
 BACKUP_DIR="${DEST_DIR}_backup-$(date +%Y%m%dT%H%M%S)"
 CLONE_ATTR=("--progress")
-REQUIRED_NVIM_VERSION_NIGHTLY=0.10
 REQUIRED_NVIM_VERSION=0.9.0
 REQUIRED_NVIM_VERSION_LEGACY=0.8.0
 USE_SSH=1
@@ -170,10 +169,8 @@ check_nvim_version() {
 	fi
 }
 
-clone_by_https_or_ssh() {
-	if check_nvim_version "${REQUIRED_NVIM_VERSION_NIGHTLY}"; then
-		execute "git" "clone" "-b" "0.10" "${CLONE_ATTR[@]}" "$1" "${DEST_DIR}"
-	elif check_nvim_version "${REQUIRED_NVIM_VERSION}"; then
+clone_repo() {
+	if check_nvim_version "${REQUIRED_NVIM_VERSION}"; then
 		execute "git" "clone" "-b" "main" "${CLONE_ATTR[@]}" "$1" "${DEST_DIR}"
 	elif check_nvim_version "${REQUIRED_NVIM_VERSION_LEGACY}"; then
 		warn "You have outdated Nvim installed (< ${REQUIRED_NVIM_VERSION})."
@@ -273,9 +270,9 @@ fi
 
 info "Fetching in progress..."
 if [[ "${USE_SSH}" -eq "1" ]]; then
-	clone_by_https_or_ssh "git@github.com:ayamir/nvimdots.git"
+	clone_repo "git@github.com:ayamir/nvimdots.git"
 else
-	clone_by_https_or_ssh "https://github.com/ayamir/nvimdots.git"
+	clone_repo "https://github.com/ayamir/nvimdots.git"
 fi
 
 cd "${DEST_DIR}" || return

--- a/tutor/dots.tutor
+++ b/tutor/dots.tutor
@@ -1,43 +1,47 @@
-# Welcome to the nvimdots tutor
+# Welcome to the nvimdots Tutor
 
-Nvimdots is a neovim config suite that is designed for extensibility,
-performance, and ease of use. It provides the ability to work with textfile,
-yet feels like you are working within an IDE environment.
-This tutor will walk through how one can utilize this configuration suite to
-use Neovim as a powerful code editor.
+Nvimdots is a [neovim](https://neovim.io/) config suite designed for extensibility, performance, and ease
+of use. It provides the ability to work with text files yet feels like you are
+working within an IDE environment.
 
-As a modern neovim config, it provides all of the features you need, code
-completion, snippet run, tree-sitter, DAP, fuzzy find, and more. It comes
-with state-of-the-art (SOTA) neovim plugins from the community to provide the
-best user experience.
+This tutor will walk you through how to utilize our configuration to use neovim as a
+powerful code editor.
+
+As a modern neovim config, it provides all the features you need: code completion,
+(partial) code testing, tree-sitter, DAP, fuzzy find, and more. It comes with state-
+of-the-art (SOTA) neovim plugins from the community to provide the best user
+experience.
 
 The default [<leader>](<leader>) key is `<Space>`{normal}.
 
-The approximate time required to complete the tutor is 5 minutes, depending
-upon how much time is spent with experimentation.
+The approximate time required to complete the tutorial is 5 minutes, although the
+exact duration may vary depending on the amount of time spent experimenting.
 
-# Lesson 1.1: EXPLANATION OF UI
+# Lesson 1.1: EXPLANATION OF THE UI
 
-The opened buffers are showed at the top, you can use `<A-i>`{normal} and `<A-o>`{normal} to
-switch between them. Also, `<A-n>`{normal}(n meaning No) can be used to switch to the
-target buffer directly.
+The opened buffers are shown at the top; you can use `<A-i>`{normal} and `<A-o>`{normal} to switch
+between them. Also, `<A-n>`{normal} (with `n`{normal} being any number between 1-9) can be used to
+switch to the desired buffer directly.
 
-Note: For macOS, you need to remap your `<Option>`{normal} to `<Alt>`{normal} following the
-instructions in https://github.com/ayamir/nvimdots/issues/344.
+NOTE: macOS users may need to remap their `<Option>`{normal}`(⌥)` meta key to `<Alt>`{normal} by
+      following the instructions provided in [this link](https://github.com/ayamir/nvimdots/issues/344).
+      [https://github.com/ayamir/nvimdots/issues/344](https://github.com/ayamir/nvimdots/issues/344)
 
-You can use `<C-n>`{normal} to open/close file explorer which will appear on the left.
-Now move cursor to the line of **lua** folder, press `o`{normal} to open it, repeat this
-process to **core** folder, then open **event.lua** in new buffer by press `o`{normal} too.
-You can press `<C-h>`{normal} and `<C-l>`{normal} to move cursor to file explorer and back to
-this buffer. Since we nolonger need the file explorer in the following sections,
-please close it.
+You can utilize `<C-n>`{normal} to toggle the file explorer, which will be displayed on the
+left side of your screen. Now, navigate the cursor to the line corresponding to the
+**lua** folder, and press [o](o) to open it. Repeat this procedure until you reach the **core**
+folder, and then open **event.lua** in a new buffer by also pressing [o](o). To navigate
+between the file explorer and this buffer, you can press `<C-h>`{normal} and `<C-l>`{normal}. As the
+file explorer is no longer necessary for the subsequent sections, please close it
+using `<C-n>`{normal}.
 
-Now press `<C-w>v`{normal} to split current window vertically, then `<A-i>`{normal} switch to
-the **event.lua** buffer for the right window. You can use `<A-h>`{normal} and `<A-l>`{normal} 
-to resize the right window and ensure you can view each word of this buffer.
-Of course, the resize process can be continous by holding the key.
+Now, press `<C-w>v`{normal} to split the current window vertically. Next, utilize `<A-i>`{normal} to
+switch to the **event.lua** buffer in the right window. You can adjust the size of the
+right window using `<A-h>`{normal} and `<A-l>`{normal} to ensure that each word of this buffer is
+visible. Additionally, resizing can be extended by holding down the respective key.
 
-Back to the left window, the status line is showed at the bottom of the window.
+Returning to the left window, you should see that the status line is displayed at the
+bottom of the window.
 --------------------------------------------------------------------------------
 |Normal|󰢱 lua|main| 1|󱜙 [lua_ls,null-ls] UTF-8 LF  4|󱃪 ~/.config/nvim|4% 50:1|
 --------------------------------------------------------------------------------
@@ -50,97 +54,103 @@ Back to the left window, the status line is showed at the bottom of the window.
    |      |---- file type                                                  |
    |---- edit mode                                     cursor position ----|
 
-You will see different content under different conditions. It will looks like
-this if you switch to the right window and move cursor to the second line.
+You will encounter varying content under different conditions. If you switch to the
+right window and move the cursor to the second line, it will appear like this:
 -------------------------------------------------------------------------------
 |Normal|󰢱 lua|main| 󰅩 autocmd                  |~/.config/nvim|utf-8|LF|1%|2:1|
 -------------------------------------------------------------------------------
-"󰅩 autocmd" indicates this line has a variable named "autocmd". So this part of
-status line will show you the context of your cursor position. This feature
-is based on lsp, so it is disabled if corresponding lsp is not attach to current
-buffer.
+"󰅩 autocmd" indicates that this line contains a variable named "autocmd".
+Consequently, this segment of the status line provides insight into the context of
+your cursor position. It's important to note that this feature relies on LSP, so it
+is disabled if the corresponding LSP is not attached to the current buffer.
 
-You can press `<leader>li`{normal} to check lsp info. You will view there are two active
-clients attached to this buffer.
+You can press `<leader>li`{normal} to check LSP info. Upon doing so, you will notice that
+there are two active clients attached to this buffer.
 
-Now press `go`{normal} to open lspsaga outline which show all of symbols defined in
-**event.lua** in the new right window. Maybe you have noticed that there are
-several scroll bar for each window. They can be dragged by mouse and indicates
-current cursor approximate location.
+Now, press [go](go) to toggle the code outline, which displays all symbols defined in
+**event.lua** in the rightmost window. You may have noticed that there are several
+scrollbars for each window. These scrollbars can be dragged by your mouse and
+indicate the approximate location of the current cursor position.
 
-Before you switch to the window of dotstutor, please press `go`{normal} to close
-outline, because it's also lsp-based. So it will be empty for dotstutor.
+Before switching to the dotstutor window, please press [go](go) to close the code outline
+because it's also LSP-based. Directly changing to the dotstutor window will render it
+empty and thus useless.
 
-Now switch to the left window and check lsp info. You will see the two clients
-not attached to this buffer. It means there no suitable lsp server for this
-buffer, that's why I told you to turn outline off.
+Now switch to the left window and check LSP info. You will notice that the two
+clients are not attached to this buffer. This indicates that there is no suitable LSP
+server for this buffer, which is why I advised you to turn off the outline.
 
-OK, now you have known enough about the UI of nvimdots. Let's move on to the
-next topic about the basic workflow.
+Okay, now that you have familiarized yourself with the UI of nvimdots, let's proceed
+to the next topic, which covers the basic workflow.
 
-# Lesson 1.2:  FIND AND SEARCH
+# Lesson 1.2: FIND AND SEARCH
 
-Nvimdots use "telescope.nvim" as the main fuzzy finder. It provides lots of
-features to find and search. You can press `<leader>ff`{normal} to open file finder
-under current work directory. You can input the keyword of file which you want
-find and use `<C-p>`{normal} and `<C-n>`{normal} to navigate up and down. You can preview its
-content in the right window and press enter to open it in buffer.
+Nvimdots utilizes [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) as the primary fuzzy finder. It offers numerous
+features for finding and searching. To open the file finder under the current
+working directory, press `<leader>ff`{normal}. Then, input the keyword you wish to find and use
+`<C-p>`{normal} and `<C-n>`{normal} to navigate up and down the list of results. You can preview the
+content of the selected file in the right window and press `<Enter>`{normal} to open it
+in a new buffer.
 
-Nvimdots also provide other find features. The most commonly used keymap maybe
-`<leader>fr`{normal} if you are used to editing files in different projects. It will
-list files you ever opened and sort them by "frecency" which used in firefox's
-address bar. This feature uses "Lua Bytecode" to store the key-value pairs of
-file path and its "frecency" value permanently at:
-**~/.local/share/nvim/file_frecency.bin**.
+Nvimdots also provide several additional search features. One commonly used keymap is
+`<leader>fr`{normal}, especially if you frequently edit files across different projects. This
+command lists files you have previously opened and sorts them by "frecency," a
+concept similar to that used in Firefox's address bar. This feature utilizes "Lua
+Bytecode" to permanently store the key-value pairs of file paths and their "frecency"
+values at **~/.local/share/nvim/file_frecency.bin**.
 
-You can press `<leader>fw`{normal} to search word in current work directory. It
-utilizes ripgrep to search and you can use it naturally as you use ripgrep.
+You can press `<leader>fw`{normal} to search for a word in the current working directory. This
+feature utilizes [ripgrep](https://github.com/BurntSushi/ripgrep) for searching, allowing you to use it naturally as you would
+with ripgrep.
 
-Nvimdots provides project management feature and integrates it with telescope.
-You can press `<leader>fp`{normal} to open recent project list. Don't quit this inter-
-face, you can add current work directory to project list by pressing `<C-a>`{normal}
-and remove it by pressing `<C-d>`{normal}. The current work directory is usually the
-project directory which are identfied by lsp and patterns like git. Of course,
-you can set patterns on your own. So it will change automatically when you
-switch to another buffer whose file belongs to another project.
+Nvimdots also provides project management features and integrates them seamlessly
+with telescope. Press `<leader>fp`{normal} to open the recent project list. Please refrain from
+quitting this interface; instead, you can add the current working directory to the
+project list by pressing `<C-a>`{normal}, and remove it by pressing `<C-d>`{normal}. Typically, the
+current working directory corresponds to the project directory, which is identified
+by LSP and patterns such as *.git/*. However, you have the flexibility to set your own
+patterns. Consequently, the project directory will automatically change when you
+switch to another buffer whose file belongs to a different project.
 
-# Lesson 1.3:  Edit and Format
+# Lesson 1.3: EDIT AND FORMAT
 
-The completion window will always show no matter what file you are editing.
-You can use `<Tab>`{normal} and `<S-Tab>`{normal} to select next and previous candidate in
-the completion window and use `<CR>`{normal} to confirm completion. You can also use
-`<C-n>`{normal} and `<C-p>`{normal} and `<C-y>`{normal} to do it. Sometimes you don't want confirm
-completion but just want to new a line, you can use `<C-w>`{normal} to close the
-window manually.
+The completion window will always appear regardless of the file you are editing. You
+can use `<Tab>`{normal} and `<S-Tab>`{normal} to navigate to the next and previous candidate in the
+completion window, and `<CR>`{normal} to confirm the completion. Alternatively, you can utilize
+`<C-n>`{normal}, `<C-p>`{normal}, and `<C-y>`{normal} for the same purpose. In instances where you prefer not to
+confirm the completion but instead start a new line, you can manually close the
+window using `<C-w>`{normal}.
 
-There are more functions provided by lsp besides code completion.
-For a former vscode user, you can experienced lots of vscode-like features,
-i.e., smart rename, find references, goto definition, view docs of some
-functions etc. No matter you heard about lsp or not, all relevant keymaps are
-very intuitive, so just try it out!
+In addition to code completion, LSPs provide various other features. Former VSCode
+users can experience many VSCode-like features such as smart rename, find references,
+go to definition, and view documentation of functions. Whether you're familiar with
+LSPs or not, all relevant keymaps are highly intuitive, so feel free to explore and
+try them out!
 
-Snippet is an awesome method to help us write code more productively.
-As most other editors and IDEs, `<Tab>`{normal} and `<S-Tab>`{normal} are configured to
-navigate in expanded snippet, the former keymap is used to jump next and the
-latter to jump previous.
+Snippet is an excellent tool to enhance productivity in code writing. Similar to most
+other editors and IDEs, `<Tab>`{normal} and `<S-Tab>`{normal} are configured to navigate within expanded
+snippets. The `<Tab>`{normal} keymap is used to move to the next snippet, while `<S-Tab>`{normal} is used
+to move to the previous one.
 
-Format on save is a very useful feature which is enabled by default. It can
-ensure the code style is consistent and you don't need to care about it.
-You can disable it temprarily by using shortcut `<A-f>`{normal} and permanently
-by adding **settings["format_on_save"] = false** in **lua/user/settings.lua**.
-Besides, you can just toggle it for specific language temprarily by executing
+Format on save is also a very useful feature that is enabled by default. It ensures
+consistent code style, relieving you from the need to manually maintain it. You can
+temporarily disable it using the shortcut `<A-f>`{normal}, and permanently by appending
+**settings["format_on_save"] = false** in **lua/user/settings.lua**.
+
+Additionally, you can toggle it for a specific language temporarily by executing:
 ~~~ cmd
     :FormatterToggleFt {language_name} <CR>
 ~~~
-
 # Lesson 1: SUMMARY
 
-Congratulations! You have learned 60% features nvimdots provided till now.
-Of course you will be curious about where you can master the rest 40%. And the
-answer relies on the basic nvim motions. We enhanced lots of nvim's default
-abilities that you can use those abilities naturally if you were already an
-experienced nvim user.
-You can also check https://github.com/ayamir/nvimdots/wiki for more!
+Congratulations! You have learned 60% of the features provided by nvimdots so far.
+Undoubtedly, you may be curious about where you can master the remaining 40%. The
+answer lies in mastering the basic neovim motions. We have enhanced many of neovim's
+default abilities, allowing you to use them naturally if you are already an
+experienced neovim user. Additionally, you can explore more features by checking out
+https://github.com/ayamir/nvimdots/wiki!
 
-Last but not least, you can press `<C-p>` in noraml mode to call the command
-panel then search for keymaps any time you want!
+Last but not least, you can press `<C-p>`{normal} in normal mode to open the command panel and
+search for keymaps anytime you want!
+
+// vim: nowrap


### PR DESCRIPTION
This commit mainly tackled several minor touch-ups and syntax improvements:

- Addressed `luacheck` issues from previous commits.
- Added some to-do comments for `_buf_vtext`.
- Eliminated redundant/outdated options.
- Temporarily removed the ability to install nightly-version configs and updated the names of relevant functions: - `clone_by_https_or_ssh` -> `clone_repo`
- Rewrote `dotstutor` to make it more readable.