### PR TITLE
feat(cmp): more completion candidates from opened buffers.

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -172,7 +172,7 @@ return function()
 			{ name = "orgmode" },
 			{
 				name = "buffer",
-				opts = {
+				option = {
 					get_bufnrs = function()
 						return vim.api.nvim_list_bufs()
 					end,

--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -170,7 +170,14 @@ return function()
 			{ name = "spell" },
 			{ name = "tmux" },
 			{ name = "orgmode" },
-			{ name = "buffer" },
+			{
+				name = "buffer",
+				opts = {
+					get_bufnrs = function()
+						return vim.api.nvim_list_bufs()
+					end,
+				},
+			},
 			{ name = "latex_symbols" },
 			{ name = "copilot" },
 			-- { name = "codeium" },


### PR DESCRIPTION
using that, buffer completion include all buffer, not only one buffer.

https://github.com/hrsh7th/cmp-buffer

get_bufnrs (type: fun(): number[])
Default: function() return { vim.api.nvim_get_current_buf() } end

A function that specifies the buffer numbers to complete.