### PR TITLE
fix(todo-comment): add missing keywords

### DIFF
--- a/lua/modules/configs/ui/todo.lua
+++ b/lua/modules/configs/ui/todo.lua
@@ -17,6 +17,7 @@ return function()
 			WARN = { icon = icons.diagnostics.Warning, color = "warning", alt = { "WARNING", "XXX" } },
 			PERF = { icon = icons.ui.Perf, alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
 			NOTE = { icon = icons.ui.Note, color = "hint", alt = { "INFO" } },
+			TEST = { icon = icons.ui.Lock, color = "test", alt = { "TESTING", "PASSED", "FAILED" } },
 		},
 		gui_style = {
 			fg = "NONE",
@@ -29,7 +30,7 @@ return function()
 			after = "",
 			comments_only = true,
 			max_line_len = 500,
-			exclude = { "big_file_disabled_ft" },
+			exclude = { "big_file_disabled_ft", "checkhealth" },
 		},
 		colors = {
 			error = { "DiagnosticError", "ErrorMsg", "#DC2626" },


### PR DESCRIPTION
there are some minor issue w/ current `todo-comment.nvim`'s config:

In `colors`, we define it as following
```lua
		colors = {
			error = { "DiagnosticError", "ErrorMsg", "#DC2626" },
			warning = { "DiagnosticWarn", "WarningMsg", "#ff8800" },
			info = { "DiagnosticInfo", "#2563EB" },
			hint = { "DiagnosticHint", "#F5C2E7" },
			default = { "Conditional", "#7C3AED" },
			test = { "Identifier", "#4FC1FF" },
		},
```
![image](https://github.com/ayamir/nvimdots/assets/32497323/7f3c7686-d952-469b-92ed-6b635ad84388)

However, it's over written to these colors:
![image](https://github.com/ayamir/nvimdots/assets/32497323/b56c6c95-e1a4-41af-a899-4d39c41ed8bb)

In `:Inspect`
![image](https://github.com/ayamir/nvimdots/assets/32497323/4225d0da-df3b-4b51-a15f-734698dca25e)
![image](https://github.com/ayamir/nvimdots/assets/32497323/a8bd35b9-f16c-426a-a2f6-2b00a5ab7c17)

Should we just remove the `colors` section or enforce colors as such:
```lua
	local error_red = "#F44747"
	local warning_orange = "#ff8800"
	local info_yellow = "#FFCC66"
	local hint_blue = "#4FC1FF"
	local perf_purple = "#7C3AED"
	local note_green = "#10B981"

	require("modules.utils").load_plugin("todo-comments", {
		signs = true, -- show icons in the signs column
		sign_priority = 8, -- sign priority
		-- keywords recognized as todo comments
		keywords = {
			FIX = {
				icon = icons.ui.Bug, -- icon used for the sign, and in search results
				color = error_red, -- can be a hex color, or a named color (see below)
				alt = { "FIXME", "BUG", "FIXIT", "ISSUE" }, -- a set of other keywords that all map to this FIX keywords
				-- signs = false, -- configure signs for some keywords individually
			},
			TODO = { icon = icons.ui.Check, color = hint_blue, alt = { "TIP" } },
			HACK = { icon = icons.ui.Fire, color = warning_orange },
			WARN = { icon = icons.diagnostics.Warning, color = warning_orange, alt = { "WARNING", "XXX" } },
			PERF = { icon = icons.ui.Perf, color = perf_purple, alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" } },
			NOTE = { icon = icons.ui.Note, color = note_green, alt = { "INFO" } },
			TEST = { icon = icons.ui.Lock, color = info_yellow, alt = { "TESTING", "PASSED", "FAILED" } },
		},
```