### PR TITLE
fix(lualine): disable default separators for custom separator

### DIFF
--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -132,6 +132,7 @@ return function()
 			end,
 			padding = 0,
 			color = utils.gen_hl("surface1", true, true),
+			separator = { left = "", right = "" },
 		},
 
 		file_status = {


### PR DESCRIPTION
I know the commit message might be a bit difficult to grasp, but I'm struggling to find a clearer way to describe it :( Essentially, this commit ensures that when our custom separator is used, default separators (as defined by `section_separators` and `component_separators`) are not added to the statusline. This prevents certain extreme scenarios where the default separator cannot be concealed, such as when in terminal mode with `:ToggleTerm direction=horizontal`.