### PR TITLE
fix: inlay_hint error

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -30,7 +30,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 			and client.server_capabilities.inlayHintProvider ~= nil
 			and type(enable_inlayhint) == "boolean"
 		then
-			vim.lsp.inlay_hint.enable(event.buf, enable_inlayhint)
+			vim.lsp.inlay_hint.enable(enable_inlayhint, { bufnr = event.buf })
 		end
 	end,
 })


### PR DESCRIPTION
After the commit [`f1dfe32`](https://github.com/neovim/neovim/commit/f1dfe32bf5552197e0068298b0527526a4f918b1) in `neovim`, the function `vim.lsp.inlay_hint.enable(buffer_number, enable)` was changed to `vim.lsp.inlay_hint.enable(enable: boolean, filter: table)`, where the original approach would lead to an error.

**I suspect there could be further changes to this API.**