### PR TITLE
pref: disable `<C-e>` for open-in-place inside nvim-tree

### DIFF
--- a/lua/modules/configs/tool/nvim-tree.lua
+++ b/lua/modules/configs/tool/nvim-tree.lua
@@ -18,8 +18,7 @@ return function()
 		sort_by = "name",
 		sync_root_with_cwd = true,
 		on_attach = function(bufnr)
-			local api = require("nvim-tree.api")
-			api.config.mappings.default_on_attach(bufnr)
+			require("nvim-tree.api").config.mappings.default_on_attach(bufnr)
 			vim.keymap.del("n", "<C-e>", { buffer = bufnr })
 		end,
 		view = {

--- a/lua/modules/configs/tool/nvim-tree.lua
+++ b/lua/modules/configs/tool/nvim-tree.lua
@@ -17,6 +17,11 @@ return function()
 		respect_buf_cwd = false,
 		sort_by = "name",
 		sync_root_with_cwd = true,
+		on_attach = function(bufnr)
+			local api = require("nvim-tree.api")
+			api.config.mappings.default_on_attach(bufnr)
+			vim.keymap.del("n", "<C-e>", { buffer = bufnr })
+		end,
 		view = {
 			adaptive_size = false,
 			centralize_selection = false,


### PR DESCRIPTION
This PR disable `<C-e>` in `nvim-tree` buffer which will open file in place originally. IMO just leaving it to scroll is better and we usually don't want to open a file in such a narrow buffer.