### PR TITLE
feat(catppuccin): remove all styles of `@property`

### DIFF
--- a/lua/modules/configs/ui/catppuccin.lua
+++ b/lua/modules/configs/ui/catppuccin.lua
@@ -17,7 +17,6 @@ return function()
 		compile_path = vim.fn.stdpath("cache") .. "/catppuccin",
 		styles = {
 			comments = { "italic" },
-			properties = { "italic" },
 			functions = { "bold" },
 			keywords = { "italic" },
 			operators = { "bold" },
@@ -28,6 +27,7 @@ return function()
 			types = {},
 			strings = {},
 			variables = {},
+			properties = {},
 		},
 		integrations = {
 			treesitter = true,


### PR DESCRIPTION
Based on the [upstream spec](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#types), `@property` is typically associated with the "key" in key/value pairs. So IMO since we don't give special treatment to the "values" (such as assigning them an "italic" property), we should treat the "keys" in the same manner as well.