### PR TITLE
fix: set rustaceanvim version to ^4

### DIFF
--- a/lua/modules/plugins/lang.lua
+++ b/lua/modules/plugins/lang.lua
@@ -18,7 +18,7 @@ lang["ray-x/go.nvim"] = {
 lang["mrcjkb/rustaceanvim"] = {
 	lazy = true,
 	ft = "rust",
-	version = "^3",
+	version = "^4",
 	init = require("lang.rust"),
 	dependencies = { "nvim-lua/plenary.nvim" },
 }


### PR DESCRIPTION
rustaceanvim does work on my computer and ^4 is recommended on rustaceanvim README.md