### PR TITLE
fix: utilize `ts-context` in `glance` preview window

### DIFF
--- a/lua/modules/configs/editor/ts-context.lua
+++ b/lua/modules/configs/editor/ts-context.lua
@@ -5,7 +5,7 @@ return function()
 		min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
 		line_numbers = true,
 		multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
-		trim_scope = "outer", -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
+		trim_scope = "inner", -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
 		mode = "cursor", -- Line used to calculate context. Choices: 'cursor', 'topline'
 		zindex = 50,
 	})

--- a/lua/modules/configs/editor/ts-context.lua
+++ b/lua/modules/configs/editor/ts-context.lua
@@ -7,6 +7,6 @@ return function()
 		multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
 		trim_scope = "outer", -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
 		mode = "cursor", -- Line used to calculate context. Choices: 'cursor', 'topline'
-		zindex = 30,
+		zindex = 50,
 	})
 end

--- a/lua/modules/configs/editor/ts-context.lua
+++ b/lua/modules/configs/editor/ts-context.lua
@@ -7,6 +7,7 @@ return function()
 		multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
 		trim_scope = "inner", -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
 		mode = "cursor", -- Line used to calculate context. Choices: 'cursor', 'topline'
+		-- HACK: to make use of `ts-context` in `glance`, set zindex to 50.(glance zindex is 45)
 		zindex = 50,
 	})
 end


### PR DESCRIPTION
default zindex of glance [dnlhc/glance.nvim] floatterm is 45. It can display on glance.