### PR TITLE
feat(trouble)!: v3 support

### DIFF
--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -63,24 +63,19 @@ local plug_map = {
 		:with_desc("git: Toggle lazygit"),
 
 	-- Plugin: trouble
-	["n|gt"] = map_cr("TroubleToggle"):with_noremap():with_silent():with_desc("lsp: Toggle trouble list"),
-	["n|<leader>ll"] = map_cr("TroubleToggle lsp_references")
-		:with_noremap()
-		:with_silent()
-		:with_desc("lsp: Show lsp references"),
-	["n|<leader>ld"] = map_cr("TroubleToggle document_diagnostics")
-		:with_noremap()
-		:with_silent()
-		:with_desc("lsp: Show document diagnostics"),
-	["n|<leader>lw"] = map_cr("TroubleToggle workspace_diagnostics")
+	["n|gt"] = map_cr("Trouble diagnostics toggle"):with_noremap():with_silent():with_desc("lsp: Toggle trouble list"),
+	["n|<leader>lw"] = map_cr("Trouble diagnostics toggle")
 		:with_noremap()
 		:with_silent()
 		:with_desc("lsp: Show workspace diagnostics"),
-	["n|<leader>lq"] = map_cr("TroubleToggle quickfix")
+	["n|<leader>lp"] = map_cr("Trouble project_diagnostics toggle")
 		:with_noremap()
 		:with_silent()
-		:with_desc("lsp: Show quickfix list"),
-	["n|<leader>lL"] = map_cr("TroubleToggle loclist"):with_noremap():with_silent():with_desc("lsp: Show loclist"),
+		:with_desc("lsp: Show project diagnostics"),
+	["n|<leader>ld"] = map_cr("Trouble diagnostics toggle filter.buf=0")
+		:with_noremap()
+		:with_silent()
+		:with_desc("lsp: Show document diagnostics"),
 
 	-- Plugin: telescope
 	["n|<C-p>"] = map_callback(function()

--- a/lua/modules/configs/tool/trouble.lua
+++ b/lua/modules/configs/tool/trouble.lua
@@ -9,8 +9,9 @@ return function()
 		auto_jump = false,
 		auto_preview = true,
 		auto_refresh = true,
-		restore = true,
+		focus = false, -- do not focus the window when opened
 		follow = true,
+		restore = true,
 		icons = {
 			indent = {
 				fold_open = icons.ui.ArrowOpen,

--- a/lua/modules/configs/tool/trouble.lua
+++ b/lua/modules/configs/tool/trouble.lua
@@ -3,7 +3,7 @@ return function()
 		ui = require("modules.utils.icons").get("ui", true),
 	}
 
-	require("trouble").setup({
+	require("modules.utils").load_plugin("trouble", {
 		auto_open = false,
 		auto_close = false,
 		auto_jump = false,

--- a/lua/modules/configs/tool/trouble.lua
+++ b/lua/modules/configs/tool/trouble.lua
@@ -1,55 +1,37 @@
 return function()
 	local icons = {
-		ui = require("modules.utils.icons").get("ui"),
-		diagnostics = require("modules.utils.icons").get("diagnostics"),
+		ui = require("modules.utils.icons").get("ui", true),
 	}
 
-	require("modules.utils").load_plugin("trouble", {
-		position = "bottom", -- position of the list can be: bottom, top, left, right
-		height = 10, -- height of the trouble list when position is top or bottom
-		width = 50, -- width of the list when position is left or right
-		icons = true, -- use devicons for filenames
-		mode = "document_diagnostics", -- "workspace_diagnostics", "document_diagnostics", "quickfix", "lsp_references", "loclist"
-		fold_open = icons.ui.ArrowOpen, -- icon used for open folds
-		fold_closed = icons.ui.ArrowClosed, -- icon used for closed folds
-		group = true, -- group results by file
-		padding = true, -- add an extra new line on top of the list
-		action_keys = {
-			-- key mappings for actions in the trouble list
-			-- map to {} to remove a mapping, for example:
-			-- close = {},
-			close = "q", -- close the list
-			cancel = "<Esc>", -- cancel the preview and get back to your last window / buffer / cursor
-			refresh = "r", -- manually refresh
-			jump = { "<CR>", "<TAB>" }, -- jump to the diagnostic or open / close folds
-			open_split = { "<C-x>" }, -- open buffer in new split
-			open_vsplit = { "<C-v>" }, -- open buffer in new vsplit
-			open_tab = { "<C-t>" }, -- open buffer in new tab
-			jump_close = { "o" }, -- jump to the diagnostic and close the list
-			toggle_mode = "m", -- toggle between "workspace" and "document" diagnostics mode
-			toggle_preview = "P", -- toggle auto_preview
-			hover = "K", -- opens a small popup with the full multiline message
-			preview = "p", -- preview the diagnostic location
-			close_folds = { "zM", "zm" }, -- close all folds
-			open_folds = { "zR", "zr" }, -- open all folds
-			toggle_fold = { "zA", "za" }, -- toggle fold of current file
-			previous = "k", -- preview item
-			next = "j", -- next item
+	require("trouble").setup({
+		auto_open = false,
+		auto_close = false,
+		auto_jump = false,
+		auto_preview = true,
+		auto_refresh = true,
+		restore = true,
+		follow = true,
+		icons = {
+			indent = {
+				fold_open = icons.ui.ArrowOpen,
+				fold_closed = icons.ui.ArrowClosed,
+			},
+			folder_closed = icons.ui.Folder,
+			folder_open = icons.ui.FolderOpen,
 		},
-		indent_lines = true, -- add an indent guide below the fold icons
-		auto_open = false, -- automatically open the list when you have diagnostics
-		auto_close = false, -- automatically close the list when you have no diagnostics
-		auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
-		auto_fold = false, -- automatically fold a file trouble list at creation
-		auto_jump = { "lsp_definitions" }, -- for the given modes, automatically jump if there is only a single result
-		signs = {
-			-- icons / text used for a diagnostic
-			error = icons.diagnostics.Error_alt,
-			warning = icons.diagnostics.Warning_alt,
-			hint = icons.diagnostics.Hint_alt,
-			information = icons.diagnostics.Information_alt,
-			other = icons.diagnostics.Question_alt,
+		modes = {
+			project_diagnostics = {
+				mode = "diagnostics",
+				filter = {
+					any = {
+						{
+							function(item)
+								return item.filename:find(vim.fn.getcwd(), 1, true)
+							end,
+						},
+					},
+				},
+			},
 		},
-		use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
 	})
 end

--- a/lua/modules/configs/ui/catppuccin.lua
+++ b/lua/modules/configs/ui/catppuccin.lua
@@ -146,6 +146,7 @@ return function()
 
 					-- For trouble.nvim
 					TroubleNormal = { bg = transparent_background and cp.none or cp.base },
+					TroubleNormalNC = { bg = transparent_background and cp.none or cp.base },
 
 					-- For telescope.nvim
 					TelescopeMatching = { fg = cp.lavender },


### PR DESCRIPTION
This PR includes the following changes:

- **REMOVED** all features unrelated to the original purpose of `trouble.nvim`, such as LSP References ([Glance](https://github.com/DNLHC/glance.nvim) covers this) and qf-list preview ([bqf](https://github.com/kevinhwang91/nvim-bqf) handles this).

- Added a custom mapping for searching project diagnostics. This is slightly different from workspace diagnostics: one is defined by the language server itself (e.g., see [LuaLS's documentation on workspace diagnostics](https://github.com/LuaLS/lua-language-server/wiki/Libraries)), while the other is determined with assistance from `project.nvim`.

- General cleanup: I deliberately excluded `trouble.nvim`'s LspKind support (e.g., LSP definitions, references, implementations, type definitions, etc.) from our config this time bc imho it's a feature we likely won't use and supporting it is a _real_ hassle.