### PR TITLE
chore(global): cleanup legacy code

### DIFF
--- a/lua/core/global.lua
+++ b/lua/core/global.lua
@@ -7,12 +7,10 @@ function global:load_variables()
 	self.is_windows = os_name == "Windows_NT"
 	self.is_wsl = vim.fn.has("wsl") == 1
 	self.vim_path = vim.fn.stdpath("config")
-	local path_sep = self.is_windows and "\\" or "/"
-	local home = self.is_windows and os.getenv("USERPROFILE") or os.getenv("HOME")
-	self.cache_dir = home .. path_sep .. ".cache" .. path_sep .. "nvim" .. path_sep
-	self.modules_dir = self.vim_path .. path_sep .. "modules"
-	self.home = home
+	self.cache_dir = vim.fn.stdpath("cache")
 	self.data_dir = string.format("%s/site/", vim.fn.stdpath("data"))
+	self.modules_dir = self.vim_path .. "/modules"
+	self.home = self.is_windows and os.getenv("USERPROFILE") or os.getenv("HOME")
 end
 
 global:load_variables()


### PR DESCRIPTION
All of these "workarounds" should no longer be necessary since Neovim v0.6 or so.

---

Created with `gh pr create`
