### PR TITLE
fix(core): missing leading path separator

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -4,11 +4,11 @@ local global = require("core.global")
 -- Create cache dir and data dirs
 local createdir = function()
 	local data_dirs = {
-		global.cache_dir .. "backup",
-		global.cache_dir .. "session",
-		global.cache_dir .. "swap",
-		global.cache_dir .. "tags",
-		global.cache_dir .. "undo",
+		global.cache_dir .. "/backup",
+		global.cache_dir .. "/session",
+		global.cache_dir .. "/swap",
+		global.cache_dir .. "/tags",
+		global.cache_dir .. "/undo",
 	}
 	-- Only check whether cache_dir exists, this would be enough.
 	if vim.fn.isdirectory(global.cache_dir) == 0 then

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -2,10 +2,10 @@ local global = require("core.global")
 
 local function load_options()
 	local global_local = {
-		-- backupdir = global.cache_dir .. "backup/",
-		-- directory = global.cache_dir .. "swap/",
-		-- spellfile = global.cache_dir .. "spell/en.uft-8.add",
-		-- viewdir = global.cache_dir .. "view/",
+		-- backupdir = global.cache_dir .. "/backup/",
+		-- directory = global.cache_dir .. "/swap/",
+		-- spellfile = global.cache_dir .. "/spell/en.uft-8.add",
+		-- viewdir = global.cache_dir .. "/view/",
 		autoindent = true,
 		autoread = true,
 		autowrite = true,
@@ -84,7 +84,7 @@ local function load_options()
 		timeoutlen = 300,
 		ttimeout = true,
 		ttimeoutlen = 0,
-		undodir = global.cache_dir .. "undo/",
+		undodir = global.cache_dir .. "/undo/",
 		undofile = true,
 		-- Please do NOT set `updatetime` to above 500, otherwise most plugins may not function correctly
 		updatetime = 200,


### PR DESCRIPTION
This is to mitigate a regression introduced by #1296, where a leading path separator is needed to properly delineate the path returned by `stdpath()`.

---

Created with `gh pr create`
