### PR TITLE
feat(treesitter): lessened performance restrictions

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -171,7 +171,7 @@ return function()
 				name = "buffer",
 				option = {
 					get_bufnrs = function()
-						return vim.api.nvim_list_bufs()
+						return vim.api.nvim_buf_line_count(0) < 7500 and { vim.api.nvim_list_bufs() } or {}
 					end,
 				},
 			},

--- a/lua/modules/configs/editor/bigfile.lua
+++ b/lua/modules/configs/editor/bigfile.lua
@@ -16,15 +16,16 @@ return function()
 	}
 
 	require("modules.utils").load_plugin("bigfile", {
-		filesize = 1, -- size of the file in MiB
+		filesize = 2, -- size of the file in MiB
 		pattern = { "*" }, -- autocmd pattern
 		features = { -- features to disable
+			"indent_blankline",
 			"lsp",
-			"treesitter",
 			"syntax",
+			"treesitter",
 			"vimopts",
-			ftdetect,
 			cmp,
+			ftdetect,
 		},
 	})
 end

--- a/lua/modules/configs/editor/rainbow_delims.lua
+++ b/lua/modules/configs/editor/rainbow_delims.lua
@@ -2,6 +2,13 @@ return function()
 	---@param threshold number @Use global strategy if nr of lines exceeds this value
 	local function init_strategy(threshold)
 		return function()
+			-- Disable on very large files
+			local line_count = vim.api.nvim_buf_line_count(0)
+			if line_count > 7500 then
+				return nil
+			end
+
+			-- Disable on parser error
 			local errors = 200
 			vim.treesitter.get_parser():for_each_tree(function(lt)
 				if lt:root():has_error() and errors >= 0 then
@@ -11,7 +18,8 @@ return function()
 			if errors < 0 then
 				return nil
 			end
-			return vim.fn.line("$") > threshold and require("rainbow-delimiters").strategy["global"]
+
+			return line_count > threshold and require("rainbow-delimiters").strategy["global"]
 				or require("rainbow-delimiters").strategy["local"]
 		end
 	end
@@ -19,8 +27,8 @@ return function()
 	vim.g.rainbow_delimiters = {
 		strategy = {
 			[""] = init_strategy(500),
-			c = init_strategy(200),
-			cpp = init_strategy(200),
+			c = init_strategy(300),
+			cpp = init_strategy(300),
 			lua = init_strategy(500),
 			vimdoc = init_strategy(300),
 			vim = init_strategy(300),
@@ -40,5 +48,6 @@ return function()
 			"RainbowDelimiterViolet",
 		},
 	}
+
 	require("modules.utils").load_plugin("rainbow_delimiters", nil, true)
 end

--- a/lua/modules/configs/editor/treesitter.lua
+++ b/lua/modules/configs/editor/treesitter.lua
@@ -9,7 +9,10 @@ return vim.schedule_wrap(function()
 		highlight = {
 			enable = true,
 			disable = function(ft, bufnr)
-				if vim.tbl_contains({ "vim" }, ft) then
+				if
+					vim.tbl_contains({ "gitcommit" }, ft)
+					or (vim.api.nvim_buf_line_count(bufnr) > 7500 and ft ~= "vimdoc")
+				then
 					return true
 				end
 
@@ -21,6 +24,7 @@ return vim.schedule_wrap(function()
 		textobjects = {
 			select = {
 				enable = true,
+				lookahead = true,
 				keymaps = {
 					["af"] = "@function.outer",
 					["if"] = "@function.inner",
@@ -30,7 +34,7 @@ return vim.schedule_wrap(function()
 			},
 			move = {
 				enable = true,
-				set_jumps = true, -- whether to set jumps in the jumplist
+				set_jumps = true,
 				goto_next_start = {
 					["]["] = "@function.outer",
 					["]m"] = "@class.outer",
@@ -55,8 +59,8 @@ return vim.schedule_wrap(function()
 	require("nvim-treesitter.install").prefer_git = true
 	if use_ssh then
 		local parsers = require("nvim-treesitter.parsers").get_parser_configs()
-		for _, p in pairs(parsers) do
-			p.install_info.url = p.install_info.url:gsub("https://github.com/", "git@github.com:")
+		for _, parser in pairs(parsers) do
+			parser.install_info.url = parser.install_info.url:gsub("https://github.com/", "git@github.com:")
 		end
 	end
 end)


### PR DESCRIPTION
This commit lifts some of the performance restrictions previously imposed on Treesitter when incremental parsing was not yet supported. Specifically:

Treesitter will now only be disabled by default for files exceeding 7,500 lines or 2 MiB in size. Testing on an Intel i9-9880H with Apple SSD AP1024N shows noticeable lag at these thresholds.

Further testing on different CPUs and/or SSD combinations is welcome lol