### PR TITLE
fix: cmp snippets source selecting issue

### DIFF
--- a/lua/modules/configs/completion/cmp.lua
+++ b/lua/modules/configs/completion/cmp.lua
@@ -127,7 +127,6 @@ return function()
 		},
 		-- You can set mappings if you want
 		mapping = cmp.mapping.preset.insert({
-			["<CR>"] = cmp.mapping.confirm({ select = false, behavior = cmp.ConfirmBehavior.Replace }),
 			["<C-p>"] = cmp.mapping.select_prev_item(),
 			["<C-n>"] = cmp.mapping.select_next_item(),
 			["<C-d>"] = cmp.mapping.scroll_docs(-4),
@@ -151,6 +150,17 @@ return function()
 					fallback()
 				end
 			end, { "i", "s" }),
+			["<CR>"] = cmp.mapping({
+				i = function(fallback)
+					if cmp.visible() and cmp.get_active_entry() then
+						cmp.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = false })
+					else
+						fallback()
+					end
+				end,
+				s = cmp.mapping.confirm({ select = true }),
+				c = cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true }),
+			}),
 		}),
 		snippet = {
 			expand = function(args)

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -25,7 +25,11 @@ M.setup = function()
 	})
 
 	local opts = {
-		capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol.make_client_capabilities()),
+		capabilities = vim.tbl_deep_extend(
+			"force",
+			vim.lsp.protocol.make_client_capabilities(),
+			require("cmp_nvim_lsp").default_capabilities()
+		),
 	}
 	---A handler to setup all servers defined under `completion/servers/*.lua`
 	---@param lsp_name string


### PR DESCRIPTION
1. https://github.com/hrsh7th/cmp-nvim-lsp/issues/38
2. some times first candidates can't be selected with our current cmp keymaps, ~~still trying to pin-point what's the cause.~~

How to reproduce 2.
1. Open ramdon lua file
2. Type `local fu` (or other keywords that can trigger snippets) and wait for the cmp windows to pop.
3. Press `<Tab>` to select the first cmp item.

It will keep flashing but won't select any cmp item. However, it can somehow use `<Up>` and `<Down>` to select the cmp item.
This error doesn't limited to `cmp-nvim-lsp`, sometimes `luasnip` has this issue too. 
I think this issue is mostly related to snippets.


https://github.com/ayamir/nvimdots/assets/32497323/3c6b4bb8-3e16-4595-a571-265ae1d40723

