### PR TITLE
feat(nixos): add mergeLazyLock option

### DIFF
--- a/nixos/neovim/default.nix
+++ b/nixos/neovim/default.nix
@@ -26,13 +26,15 @@ in
           Bind lazy-lock.json in your repository to $XDG_CONFIG_HOME/nvim.
           Very powerful in terms of keeping the environment consistent, but has the following side effects.
           You cannot update it even if you run the Lazy command, because it binds read-only.
-          You need to remove lazy-lock.json before activation, if `mergeLazyLock` have set.
+          You need to remove lazy-lock.json before enabling this option if `mergeLazyLock` is set.
         '';
         mergeLazyLock = mkEnableOption ''
-          Merge into already existing lazy-lock.json in $XDG_CONFIG_HOME/nvim every activation.
-          This will respect the package version of lazy-lock.json in the repository.
-          Achieve environmental consistency while being flexible to change.
-          You need to unlink lazy-lock.json before activation, if `bindLazyLock` have set.
+          Merges the managed lazy-lock.json with the existing one under $XDG_CONFIG_HOME/nvim if its hash has changed on activation.
+          Upstream package version changes have high priority.
+          This means changes to lazy-lock.json in the config directory (likely due to installing package) will be preserved.
+          In other words, it achieves environment consistency while remaining adaptable to changes.
+          You need to unlink lazy-lock.json before enabling this option if `bindLazyLock` is set.
+          Please refer to the wiki for details on the behavior.
         '';
         setBuildEnv = mkEnableOption ''
           Sets environment variables that resolve build dependencies as required by `mason.nvim` and `nvim-treesitter`


### PR DESCRIPTION
https://github.com/ayamir/nvimdots/pull/1260#issuecomment-2191929399

`lazy-lock.json` managed by `nix/store` is symbolically linked to `${XDG_CONFIG_DIR}/nvim/lazy-lock.json`, but since it is read-only, there is a problem that it has low affinity with lazy.nvim.
Therefore, lazy-lock.json is managed locally, and when lazy-lock.json in the repository is updated, it is merged to achieve both reproducibility and convenience.

It will be updated with the workflow shown below when home-manager activation.

1. `lazy-lock.json` in the repository is managed as `lazy-lock.fixed.json` in `/nix/store`.
2. When created symlink to `${XDG_CONFIG_DIR}/nvim`, one of the following will be executed.
    1. Not existing `lazy-lock.json` under `${XDG_CONFIG_DIR}/nvim`, copy to then.
    2. Existing `lazy-lock.json` under then, merge two json. At this time, merge to respect the package version of the repository.
    
This workflow will not run unless lazy-lock.json in the repository is updated (path to /nix/store is not updated) (i.e. not every activation of home-manager)

The traditional `bindLazyLock` options are also retained,