### PR TITLE
update gitsigns.lua to get rid of warnings

### DIFF
--- a/lua/modules/configs/ui/gitsigns.lua
+++ b/lua/modules/configs/ui/gitsigns.lua
@@ -3,34 +3,19 @@ return function()
 	require("modules.utils").load_plugin("gitsigns", {
 		signs = {
 			add = {
-				hl = "GitSignsAdd",
 				text = "│",
-				numhl = "GitSignsAddNr",
-				linehl = "GitSignsAddLn",
 			},
 			change = {
-				hl = "GitSignsChange",
 				text = "│",
-				numhl = "GitSignsChangeNr",
-				linehl = "GitSignsChangeLn",
 			},
 			delete = {
-				hl = "GitSignsDelete",
 				text = "_",
-				numhl = "GitSignsDeleteNr",
-				linehl = "GitSignsDeleteLn",
 			},
 			topdelete = {
-				hl = "GitSignsDelete",
 				text = "‾",
-				numhl = "GitSignsDeleteNr",
-				linehl = "GitSignsDeleteLn",
 			},
 			changedelete = {
-				hl = "GitSignsChange",
 				text = "~",
-				numhl = "GitSignsChangeNr",
-				linehl = "GitSignsChangeLn",
 			},
 		},
 		on_attach = mapping.gitsigns,


### PR DESCRIPTION
when starting nvim some warnings shows up:
'signs.add.hl' is now deprecated, please define highlight 'GitSignsAdd'
'signs.add.linehl' is now deprecated, please define highlight 'GitSignsAddLn'
'signs.add.numhl' is now deprecated, please define highlight 'GitSignsAddNr'
'signs.change.hl' is now deprecated, please define highlight 'GitSignsChange'
'signs.change.linehl' is now deprecated, please define highlight 'GitSignsChangeLn'
'signs.change.numhl' is now deprecated, please define highlight 'GitSignsChangeNr'
'signs.changedelete.hl' is now deprecated, please define highlight 'GitSignsChangedelete'
'signs.changedelete.linehl' is now deprecated, please define highlight 'GitSignsChangedeleteLn'
'signs.changedelete.numhl' is now deprecated, please define highlight 'GitSignsChangedeleteNr'
'signs.delete.hl' is now deprecated, please define highlight 'GitSignsDelete'
'signs.delete.linehl' is now deprecated, please define highlight 'GitSignsDeleteLn'
'signs.delete.numhl' is now deprecated, please define highlight 'GitSignsDeleteNr'
'signs.topdelete.hl' is now deprecated, please define highlight 'GitSignsTopdelete'
'signs.topdelete.linehl' is now deprecated, please define highlight 'GitSignsTopdeleteLn'
'signs.topdelete.numhl' is now deprecated, please define highlight 'GitSignsTopdeleteNr'
