### PR TITLE
feat: credit all collaborators as copyright holders

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,30 @@
-MIT License
+BSD 3-Clause License
 
 Copyright (c) 2021 ayamir
+Copyright (c) 2022 Jint-lzxy, CharlesChiuGit
+Copyright (c) 2023 aarnphm, misumisumi
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ It's strongly recommended to read [Wiki: Prerequisites](https://github.com/ayami
 - [ayamir](https://github.com/ayamir)
 - [Jint-lzxy](https://github.com/Jint-lzxy)
 - [CharlesChiuGit](https://github.com/CharlesChiuGit)
+- [aarnphm](https://github.com/aarnphm)
+- [misumisumi](https://github.com/misumisumi)
 
 ## 🎉 Acknowledgement
 
@@ -204,7 +206,7 @@ It's strongly recommended to read [Wiki: Prerequisites](https://github.com/ayami
 
 ## 📜 License
 
-This Neovim configuration is released under the MIT license, which grants the following permissions:
+This Neovim configuration is released under the BSD 3-Clause license, which grants the following permissions:
 
 - Commercial use
 - Distribution


### PR DESCRIPTION
This PR proposes changing our config's license to the BSD 3-clause license. It also updates the README to acknowledge [aarnphm](https://github.com/aarnphm) and [misumisumi](https://github.com/misumisumi) as main contributors. I chose the BSD 3-clause license primarily because it includes a non-endorsement clause and does not permit [sublicensing](https://softwareengineering.stackexchange.com/a/189647) (which the MIT license lacks afaiu).