### PR TITLE
feat(which-key): `v3` support

### DIFF
--- a/lua/modules/configs/tool/which-key.lua
+++ b/lua/modules/configs/tool/which-key.lua
@@ -2,43 +2,19 @@ return function()
 	local icons = {
 		ui = require("modules.utils.icons").get("ui"),
 		misc = require("modules.utils.icons").get("misc"),
-		git = require("modules.utils.icons").get("git", true),
-		cmp = require("modules.utils.icons").get("cmp", true),
 	}
 
-	require("which-key").register({
-		["<leader>"] = {
-			b = {
-				name = icons.ui.Buffer .. " Buffer",
-			},
-			d = {
-				name = icons.ui.Bug .. " Debug",
-			},
-			f = {
-				name = icons.ui.Telescope .. " Fuzzy Find",
-			},
-			g = {
-				name = icons.git.Git .. "Git",
-			},
-			l = {
-				name = icons.misc.LspAvailable .. " Lsp",
-			},
-			n = {
-				name = icons.ui.FolderOpen .. " Nvim Tree",
-			},
-			p = {
-				name = icons.ui.Package .. " Package",
-			},
-			s = {
-				name = icons.cmp.tmux .. "Session",
-			},
-			S = {
-				name = icons.ui.Search .. " Search",
-			},
-			W = {
-				name = icons.ui.Window .. " Window",
-			},
-		},
+	require("which-key").add({
+		{ "<leader>S", group = "Search" },
+		{ "<leader>W", group = "Window" },
+		{ "<leader>b", group = "Buffer" },
+		{ "<leader>d", group = "Debug" },
+		{ "<leader>f", group = "Fuzzy Find", icon = icons.ui.Telescope },
+		{ "<leader>g", group = "Git" },
+		{ "<leader>l", group = "Lsp", icon = icons.misc.LspAvailable },
+		{ "<leader>n", group = "Nvim Tree", icon = icons.ui.FolderOpen },
+		{ "<leader>p", group = "Package", icon = icons.ui.Package },
+		{ "<leader>s", group = "Session" },
 	})
 
 	require("modules.utils").load_plugin("which-key", {


### PR DESCRIPTION
This pull request updates the which-key mappings to the new specification as outlined in the documentation for [version 3](https://github.com/folke/which-key.nvim?tab=readme-ov-file#%EF%B8%8F-configuration:~:text=a%20regular%20keymap.-,Warning,use%20the%20new%20add%20method%20if%20you%20updated%20your%20existing%20mappings.,-Mappings%20can%20be). The previous mappings were using the old specification, which caused warnings during the health check. The updated mappings now use the add method and are structured according to the latest guidelines.
## Before:
![5701720888312_ pic](https://github.com/user-attachments/assets/fa45f285-db1c-49b0-a305-d89e13cdbf10)
![5711720888477_ pic](https://github.com/user-attachments/assets/05936e56-18ab-4822-82a1-1a76ba2af2c2)
## After:
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/1f9b7bfa-c664-464f-bf4c-2bafb0c0b3b9">
