### PR TITLE
fix(which-key): config option `modes` has been deprecated

### DIFF
--- a/lua/modules/configs/tool/which-key.lua
+++ b/lua/modules/configs/tool/which-key.lua
@@ -9,14 +9,8 @@ return function()
 	require("modules.utils").load_plugin("which-key", {
 		preset = "classic",
 		delay = vim.o.timeoutlen,
-		modes = {
-			n = true,
-			i = true,
-			x = false,
-			s = false,
-			o = false,
-			t = false,
-			c = false,
+		triggers = {
+			{ "<auto>", mode = "nixso" },
 		},
 		plugins = {
 			marks = true,


### PR DESCRIPTION
This is a follow-up fix for which-key's v3 rewrite. It simply restores the behaviors to match v2's default, so there shouldn't be any explicit changes.

(Now the user can use which-key in visual/selection mode without the annoying box that distracts attention, which is superb 🥳)