### PR TITLE
fix: some vim plugins get disabled by mistake

### DIFF
--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -22,14 +22,6 @@ local createdir = function()
 	end
 end
 
-local load_distribution_plugins = function()
-	-- Set this to 0 in order to disable native EditorConfig support
-	vim.g.editorconfig = 1
-
-	-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
-	vim.g.netrw_liststyle = 3
-end
-
 local leader_map = function()
 	vim.g.mapleader = " "
 	-- NOTE:
@@ -104,7 +96,6 @@ end
 
 local load_core = function()
 	createdir()
-	load_distribution_plugins()
 	leader_map()
 
 	gui_config()

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -22,6 +22,16 @@ local createdir = function()
 	end
 end
 
+local load_distribution_plugins = function()
+	-- Set this to true in order to enable native EditorConfig support
+	-- WARN: Sleuth.vim already includes all the features provided by this plugin.
+	--       Do NOT enable both at the same time, or you risk breaking the entire detection system.
+	vim.g.editorconfig = false
+
+	-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
+	vim.g.netrw_liststyle = 3
+end
+
 local leader_map = function()
 	vim.g.mapleader = " "
 	-- NOTE:
@@ -96,6 +106,7 @@ end
 
 local load_core = function()
 	createdir()
+	load_distribution_plugins()
 	leader_map()
 
 	gui_config()

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -23,11 +23,6 @@ local createdir = function()
 end
 
 local load_distribution_plugins = function()
-	-- Set this to true in order to enable native EditorConfig support
-	-- WARN: Sleuth.vim already includes all the features provided by this plugin.
-	--       Do NOT enable both at the same time, or you risk breaking the entire detection system.
-	vim.g.editorconfig = false
-
 	-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
 	vim.g.netrw_liststyle = 3
 end

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -22,6 +22,14 @@ local createdir = function()
 	end
 end
 
+local load_distribution_plugins = function()
+	-- Set this to 0 in order to disable native EditorConfig support
+	vim.g.editorconfig = 1
+
+	-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
+	vim.g.netrw_liststyle = 3
+end
+
 local leader_map = function()
 	vim.g.mapleader = " "
 	-- NOTE:
@@ -96,6 +104,7 @@ end
 
 local load_core = function()
 	createdir()
+	load_distribution_plugins()
 	leader_map()
 
 	gui_config()

--- a/lua/core/init.lua
+++ b/lua/core/init.lua
@@ -22,11 +22,6 @@ local createdir = function()
 	end
 end
 
-local load_distribution_plugins = function()
-	-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
-	vim.g.netrw_liststyle = 3
-end
-
 local leader_map = function()
 	vim.g.mapleader = " "
 	-- NOTE:
@@ -101,7 +96,6 @@ end
 
 local load_core = function()
 	createdir()
-	load_distribution_plugins()
 	leader_map()
 
 	gui_config()

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -125,4 +125,7 @@ local function load_options()
 	end
 end
 
+-- Newtrw liststyle: https://medium.com/usevim/the-netrw-style-options-3ebe91d42456
+vim.g.netrw_liststyle = 3
+
 load_options()

--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -125,26 +125,23 @@ function Lazy:load_lazy()
 				---@type string[]
 				paths = {}, -- add any custom paths here that you want to include in the rtp
 				disabled_plugins = {
+					-- Do not load spell files
+					"spellfile",
 					-- Do not use builtin matchit.vim and matchparen.vim because we're using vim-matchup
 					"matchit",
 					"matchparen",
-					-- Do not load builtin netrw
-					"netrwPlugin",
 					-- Do not load tohtml.vim
 					"tohtml",
 					-- Do not load zipPlugin.vim, gzip.vim and tarPlugin.vim (all of these plugins are
 					-- related to reading files inside compressed containers)
 					"gzip",
 					"tarPlugin",
-					"tutor",
 					"zipPlugin",
 					-- Disable remote plugins
 					-- NOTE:
 					--  > Disabling rplugin.vim will make `wilder.nvim` complain about missing rplugins during :checkhealth,
 					--  > but since it's config doesn't require python rtp (strictly), it's fine to ignore that for now.
-					"rplugin",
-					-- Do not load spell files
-					"spellfile",
+					-- "rplugin",
 				},
 			},
 		},

--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -125,6 +125,10 @@ function Lazy:load_lazy()
 				---@type string[]
 				paths = {}, -- add any custom paths here that you want to include in the rtp
 				disabled_plugins = {
+					-- Set this to true in order to enable native EditorConfig support
+					-- WARN: Sleuth.vim already includes all the features provided by this plugin.
+					--       Do NOT enable both at the same time, or you risk breaking the entire detection system.
+					"editorconfig",
 					-- Do not load spell files
 					"spellfile",
 					-- Do not use builtin matchit.vim and matchparen.vim because we're using vim-matchup


### PR DESCRIPTION
This commit addresses a few regressions introduced by #1340:

* The `tutor` plugin was accidentally disabled.
* netrw, along with its configuration, was mistakenly disabled.
* EditorConfig is now being implicitly disabled, which wasn't intended before #1340.