### PR TITLE
feat(clang_format): disable formatting for all Java files

### DIFF
--- a/lua/modules/configs/completion/null-ls.lua
+++ b/lua/modules/configs/completion/null-ls.lua
@@ -17,7 +17,7 @@ return function()
 	-- Don't specify any config here if you are using the default one.
 	local sources = {
 		btns.formatting.clang_format.with({
-			filetypes = { "c", "cpp", "objc", "objcpp", "cs", "java", "cuda", "proto" },
+			filetypes = { "c", "cpp", "objc", "objcpp", "cs", "cuda", "proto" },
 			extra_args = formatter_args("clang_format"),
 		}),
 		btns.formatting.prettier.with({


### PR DESCRIPTION
This commit disables `clang_format` for all Java files. The main reason is to ensure that formatting is managed by `jdtls`, which adheres to a widely accepted standard. Given that Java developers have a strong preference for this approach, it makes more sense to let a Java-specific language server handle the formatting rather than relying on a more general-purpose formatter like `clang_format`.