### PR TITLE
fix(core): correct GUI detection post v0.10.2

### DIFF
--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -100,7 +100,7 @@ editor["mrjones2014/smart-splits.nvim"] = {
 editor["nvim-treesitter/nvim-treesitter"] = {
 	lazy = true,
 	build = function()
-		if vim.fn.has("gui_running") == 1 then
+		if #vim.api.nvim_list_uis() > 0 then
 			vim.api.nvim_command([[TSUpdate]])
 		end
 	end,


### PR DESCRIPTION
This commit resolves the change in behavior for the `has("gui_running")` check introduced after v0.10.2, which now only verifies if a real GUI (not a TUI) is running.