### PR TITLE
fix(dropbar): remove deprecated `icons.kinds.use_devicons`

### DIFF
--- a/lua/modules/configs/tool/dropbar.lua
+++ b/lua/modules/configs/tool/dropbar.lua
@@ -35,7 +35,6 @@ return function()
 		icons = {
 			enable = true,
 			kinds = {
-				use_devicons = true,
 				symbols = {
 					-- Type
 					Array = icons.type.Array,


### PR DESCRIPTION
The `icons.kinds.use_devicons` option has been deprecated. This commit simply removes it, as the detection of the appropriate devicon is now managed automatically within the relevant callbacks.

Upstream commit: https://github.com/Bekaboo/dropbar.nvim/commit/a1b893ccc96080f0d167eef6e9310a40ef85ccba