### PR TITLE
fix: client filter argument typo

### DIFF
--- a/lua/modules/configs/completion/formatting.lua
+++ b/lua/modules/configs/completion/formatting.lua
@@ -118,7 +118,7 @@ function M.format(opts)
 	end
 
 	local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-	local clients = vim.lsp.get_clients({ buffer = bufnr })
+	local clients = vim.lsp.get_clients({ bufnr = bufnr })
 
 	if opts.filter then
 		clients = opts.filter(clients)

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -164,7 +164,7 @@ return function()
 		lsp = {
 			function()
 				local buf_ft = vim.bo.filetype
-				local clients = vim.lsp.get_clients({ buffer = vim.api.nvim_get_current_buf() })
+				local clients = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })
 				local lsp_lists = {}
 				local available_servers = {}
 				if next(clients) == nil then


### PR DESCRIPTION
doc [here](https://neovim.io/doc/user/lsp.html#vim.lsp.get_clients())