### PR TITLE
fix(utils): hl-Statusline retrieval issue in toggleterm

### DIFF
--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -148,7 +148,10 @@ function M.hl_to_rgb(hl_group, use_bg, fallback_hl)
 	local hlexists = pcall(vim.api.nvim_get_hl, 0, { name = hl_group, link = false })
 
 	if hlexists then
-		local result = vim.api.nvim_get_hl(0, { name = hl_group, link = false })
+		-- FIXME: Investigate why hl-StatusLine is undefined in toggleterm and remove this workaround
+		-- (@Jint-lzxy)
+		local link = vim.bo.filetype == "toggleterm"
+		local result = vim.api.nvim_get_hl(0, { name = hl_group, link = link })
 		if use_bg then
 			hex = result.bg and string.format("#%06x", result.bg) or "NONE"
 		else


### PR DESCRIPTION
This commit should fix a weird bug where `nvim_get_hl` would return an empty dict when trying to get `hl-Statusline` inside `toggleterm`. Not 100% sure why this was happening or what exact conditions caused it, but with this fix lualine now shows the right backgrounds in terminal mode!
- **Before (notice that eg the git section doesn't have proper `guibg`):**
![before](https://github.com/user-attachments/assets/d5fa2909-69c2-4bc0-b13a-c4dc69a519ad)
- **After:**
![after](https://github.com/user-attachments/assets/b4abb8f0-af0f-4f7b-94f8-2d4c2f8cd4f2)