### PR TITLE
fix: avoid bufferline not appear when open file by telescope or nvim-tree.

### DIFF
--- a/lua/modules/plugins/ui.lua
+++ b/lua/modules/plugins/ui.lua
@@ -7,7 +7,7 @@ ui["goolord/alpha-nvim"] = {
 }
 ui["akinsho/bufferline.nvim"] = {
 	lazy = true,
-	event = { "BufReadPost", "BufAdd", "BufNewFile" },
+	event = { "BufReadPre", "BufAdd", "BufNewFile" },
 	config = require("ui.bufferline"),
 }
 ui["Jint-lzxy/nvim"] = {


### PR DESCRIPTION
Currently we set `bufferline.nvim` loaded when `BufReadPost`, it will cause the bufferline doesn't appear when we open file by telescope or nvim-tree. This patch make it load when `BufReadPre`.