### PR TITLE
feat: support user customized snippets.

### DIFF
--- a/lua/modules/configs/completion/luasnip.lua
+++ b/lua/modules/configs/completion/luasnip.lua
@@ -1,14 +1,20 @@
 return function()
-	local snippet_path = vim.fn.stdpath("config") .. "/snips/"
-	if not vim.tbl_contains(vim.opt.rtp:get(), snippet_path) then
-		vim.opt.rtp:append(snippet_path)
-	end
+	local vim_path = require("core.global").vim_path
+	local snippet_path = vim_path .. "/snips/"
+	local user_snippet_path = vim_path .. "/lua/user/snips/"
 
 	require("modules.utils").load_plugin("luasnip", {
 		history = true,
 		update_events = "TextChanged,TextChangedI",
 		delete_check_events = "TextChanged,InsertLeave",
 	}, false, require("luasnip").config.set_config)
+
+	require("luasnip.loaders.from_vscode").lazy_load({
+		paths = {
+			snippet_path,
+			user_snippet_path,
+		},
+	})
 	require("luasnip.loaders.from_lua").lazy_load()
 	require("luasnip.loaders.from_vscode").lazy_load()
 	require("luasnip.loaders.from_snipmate").lazy_load()


### PR DESCRIPTION
This patch lazy loads user's customized snippets from `lua/user/snips`.
The usage is copy `lua/snips` to `lua/user/snips/` first and create your snippets like the existing examples, i.e.:

```shell
cd ~/.config/nvim
mkdir -p ./lua/user/snips/
cp -vr ./snips/* ./lua/user/snips/
# remove existing snippets
cd ./lua/user/snips/snippets/
rm -rf *
```
Add your customized snippets for `go.json` like this:
```shell
touch go.json
nvim go.json
```
```json
{
  "if err": {
    "prefix": "ie",
    "body": "if err != nil {\n\t$1\n}\n$2",
    "description": "Snippet for if err"
  }
}
```
Then you can use it:
![image](https://github.com/user-attachments/assets/dcf6a6a5-99fa-4b7c-b6f1-f14ef806bdcd)




Close #1385 @greggh