### PR TITLE
fix(lsp): only merge configs when absolutely needed

### DIFF
--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -52,10 +52,12 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		end
 
 		local ok, custom_handler = pcall(require, "user.configs.lsp-servers." .. lsp_name)
+		local default_ok, default_handler = pcall(require, "completion.servers." .. lsp_name)
 		-- Use preset if there is no user definition
 		if not ok then
-			ok, custom_handler = pcall(require, "completion.servers." .. lsp_name)
+			ok, custom_handler = default_ok, default_handler
 		end
+
 		if not ok then
 			-- Default to use factory config for server(s) that doesn't include a spec
 			nvim_lsp[lsp_name].setup(opts)
@@ -66,7 +68,14 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 			--- See `clangd.lua` for example.
 			custom_handler(opts)
 		elseif type(custom_handler) == "table" then
-			nvim_lsp[lsp_name].setup(vim.tbl_deep_extend("force", opts, custom_handler))
+			nvim_lsp[lsp_name].setup(
+				vim.tbl_deep_extend(
+					"force",
+					opts,
+					type(default_handler) == "table" and default_handler or {},
+					custom_handler
+				)
+			)
 		else
 			vim.notify(
 				string.format(

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -52,19 +52,14 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		end
 
 		local ok, custom_handler = pcall(require, "user.configs.lsp-servers." .. lsp_name)
-		local predefined_ok, predefined = pcall(require, "completion.servers." .. lsp_name)
 		-- Use preset if there is no user definition
 		if not ok then
-			ok, custom_handler = predefined_ok, predefined
-		else
-			if type(custom_handler) == "table" and type(predefined) == "table" then
-				custom_handler = vim.tbl_deep_extend("force", predefined, custom_handler)
-			end
+			ok, custom_handler = pcall(require, "completion.servers." .. lsp_name)
 		end
-
 		if not ok then
 			-- Default to use factory config for server(s) that doesn't include a spec
 			nvim_lsp[lsp_name].setup(opts)
+			return
 		elseif type(custom_handler) == "function" then
 			--- Case where language server requires its own setup
 			--- Make sure to call require("lspconfig")[lsp_name].setup() in the function


### PR DESCRIPTION
This commit is a follow-up fix for #1376 to delay merging user & default configs as much as we can to avoid extra overhead.