### PR TITLE
fix(keymaps): update `toggle display` and `gitsigns` keymaps

### DIFF
--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -67,18 +67,6 @@ function M.lsp(buf)
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Show outgoing calls"),
-		["n|<leader>td"] = map_callback(function()
-				_toggle_diagnostic()
-			end)
-			:with_noremap()
-			:with_silent()
-			:with_desc("edit: Toggle virtual text display of current buffer"),
-		["n|<leader>th"] = map_callback(function()
-				_toggle_inlayhint()
-			end)
-			:with_noremap()
-			:with_silent()
-			:with_desc("edit: Toggle inlay hints dispaly of current buffer"),
 	}
 	bind.nvim_load_mapping(map)
 

--- a/lua/keymap/editor.lua
+++ b/lua/keymap/editor.lua
@@ -50,6 +50,20 @@ local mappings = {
 			:with_silent()
 			:with_desc("edit: Clear search highlight"),
 		["n|<leader>o"] = map_cr("setlocal spell! spelllang=en_us"):with_desc("edit: Toggle spell check"),
+
+		-- Builtins: Lsp
+		["n|<leader>td"] = map_callback(function()
+				_toggle_diagnostic()
+			end)
+			:with_noremap()
+			:with_silent()
+			:with_desc("edit: Toggle global display of virtual text"),
+		["n|<leader>th"] = map_callback(function()
+				_toggle_inlayhint()
+			end)
+			:with_noremap()
+			:with_silent()
+			:with_desc("edit: Toggle global display of inlay hints"),
 	},
 	plugins = {
 		-- Plugin: persisted.nvim

--- a/lua/keymap/ui.lua
+++ b/lua/keymap/ui.lua
@@ -123,11 +123,6 @@ function M.gitsigns(buf)
 		end)
 			:with_buffer(buf)
 			:with_desc("git: Stage hunk"),
-		["n|<leader>gu"] = bind.map_callback(function()
-			actions.undo_stage_hunk()
-		end)
-			:with_buffer(buf)
-			:with_desc("git: Undo stage hunk"),
 		["n|<leader>gr"] = bind.map_callback(function()
 			actions.reset_hunk()
 		end)
@@ -154,9 +149,7 @@ function M.gitsigns(buf)
 			:with_buffer(buf)
 			:with_desc("git: Blame line"),
 		-- Text objects
-		["ox|ih"] = bind.map_callback(function()
-			actions.text_object()
-		end):with_buffer(buf),
+		["ox|ih"] = bind.map_cu("Gitsigns select_hunk"):with_silent():with_buffer(buf),
 	}
 	bind.nvim_load_mapping(map)
 end


### PR DESCRIPTION
a break feature lewis6991/gitsigns.nvim@8b74e560f7cba19b45b7d72a3cf8fb769316d259 upstream.

Keymap `select_hunk`  is a fix according to [keymaps in readme](https://github.com/lewis6991/gitsigns.nvim/blob/main/README.md#keymaps). I tested in my PC and It only works on selecting `vih`,  not supports  `dih` and `yih`, though I think it's enough for use.

`toggle display` keymaps is moved due to https://github.com/ayamir/nvimdots/pull/1397#issuecomment-2603741689