### PR TITLE
fix：修复local-highlight.nvim更新后缺少依赖异常

### DIFF
--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -65,6 +65,10 @@ editor["tzachar/local-highlight.nvim"] = {
 	lazy = true,
 	event = { "BufReadPost", "BufAdd", "BufNewFile" },
 	config = require("editor.local-highlight"),
+	dependencies = {
+		{ "folke/snacks.nvim" },
+	},
+
 }
 editor["brenoprata10/nvim-highlight-colors"] = {
 	lazy = true,


### PR DESCRIPTION
local-highlight.nvim插件新增了依赖snacks.nvim，导致异常报错 https://github.com/tzachar/local-highlight.nvim/commit/b29692c1edbf292fb7f62552c54bc7b06e61466b