### PR TITLE
chore(keymap): clean up legacy configs & rename toggle function

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --globals vim _debugging _command_panel _flash_esc_or_noh _telescope_collections _toggle_lazygit _toggle_diagnostic _toggle_inlayhint --max-line-length 150 --no-config
+          args: . --std luajit --max-line-length 150 --no-config --globals vim _debugging _command_panel _flash_esc_or_noh _telescope_collections _toggle_inlayhint _toggle_virtualtext  _toggle_lazygit

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -68,7 +68,7 @@ function M.lsp(buf)
 			:with_buffer(buf)
 			:with_desc("lsp: Show outgoing calls"),
 		["n|<leader>lv"] = map_callback(function()
-				_toggle_diagnostic()
+				_toggle_virtualtext()
 			end)
 			:with_noremap()
 			:with_silent()

--- a/lua/keymap/helpers.lua
+++ b/lua/keymap/helpers.lua
@@ -3,12 +3,18 @@ _G._command_panel = function()
 		lhs_filter = function(lhs)
 			return not string.find(lhs, "Þ")
 		end,
-		layout_config = {
-			width = 0.6,
-			height = 0.6,
-			prompt_position = "top",
-		},
 	})
+end
+
+_G._flash_esc_or_noh = function()
+	local flash_active, state = pcall(function()
+		return require("flash.plugins.char").state
+	end)
+	if flash_active and state then
+		state:hide()
+	else
+		pcall(vim.cmd.noh)
+	end
 end
 
 _G._telescope_collections = function(picker_type)
@@ -50,7 +56,7 @@ _G._toggle_inlayhint = function()
 end
 
 local _vt_enabled = require("core.settings").diagnostics_virtual_text
-_G._toggle_diagnostic = function()
+_G._toggle_virtualtext = function()
 	if vim.diagnostic.is_enabled() then
 		_vt_enabled = not _vt_enabled
 		vim.diagnostic[_vt_enabled and "show" or "hide"]()
@@ -59,17 +65,6 @@ _G._toggle_diagnostic = function()
 			vim.log.levels.INFO,
 			{ title = "LSP Diagnostic" }
 		)
-	end
-end
-
-_G._flash_esc_or_noh = function()
-	local flash_active, state = pcall(function()
-		return require("flash.plugins.char").state
-	end)
-	if flash_active and state then
-		state:hide()
-	else
-		pcall(vim.cmd.noh)
 	end
 end
 

--- a/lua/keymap/lang.lua
+++ b/lua/keymap/lang.lua
@@ -3,12 +3,12 @@ local map_cr = bind.map_cr
 
 local mappings = {
 	plugins = {
-		-- Plugins: render-markdown.nvim
+		-- Plugin: render-markdown.nvim
 		["n|<F1>"] = map_cr("RenderMarkdown toggle")
 			:with_noremap()
 			:with_silent()
 			:with_desc("tool: toggle markdown preview within nvim"),
-		-- Plugins: MarkdownPreview
+		-- Plugin: MarkdownPreview
 		["n|<F12>"] = map_cr("MarkdownPreviewToggle"):with_noremap():with_silent():with_desc("tool: Preview markdown"),
 	},
 }


### PR DESCRIPTION
This commit removed some legacy configs (not sure where they came from...? correct me if I'm wrong!). Also renamed `_toggle_diagnostics` -> `_toggle_virtualtext` for clearer intent.