### PR TITLE
chore(matchup): enable some vim-matchup features

### DIFF
--- a/lua/modules/configs/editor/matchup.lua
+++ b/lua/modules/configs/editor/matchup.lua
@@ -1,0 +1,5 @@
+return function()
+	vim.g.matchup_transmute_enabled = 1
+	vim.g.matchup_surround_enabled = 1
+	vim.g.matchup_matchparen_offscreen = { method = "popup" }
+end

--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -102,9 +102,12 @@ editor["nvim-treesitter/nvim-treesitter"] = {
 	event = "BufReadPre",
 	config = require("editor.treesitter"),
 	dependencies = {
-		{ "andymass/vim-matchup" },
 		{ "mfussenegger/nvim-treehopper" },
 		{ "nvim-treesitter/nvim-treesitter-textobjects" },
+		{
+			"andymass/vim-matchup",
+			init = require("editor.matchup"),
+		},
 		{
 			"windwp/nvim-ts-autotag",
 			config = require("editor.autotag"),


### PR DESCRIPTION
This commit turned on a few vim-matchup features that pair nicely with treesitter imo.