### PR TITLE
fix(mason): add nil check to on_stderr callback in install-pylsp-plugins

### DIFF
--- a/lua/modules/configs/completion/mason.lua
+++ b/lua/modules/configs/completion/mason.lua
@@ -83,7 +83,9 @@ M.setup = function()
 						)
 					end,
 					on_stderr = function(_, msg_stream)
-						vim.notify(msg_stream, vim.log.levels.ERROR, { title = "[lsp] Install Failure" })
+						if msg_stream then
+							vim.notify(msg_stream, vim.log.levels.ERROR, { title = "[lsp] Install Failure" })
+						end
 					end,
 				})
 				:start()


### PR DESCRIPTION
The luv doc says the `on_stderr` callback is also called whenever the program exits, not just when smth is written to stderr. So we should only notify if there's a real error in `msg_stream`.