### PR TITLE
Revert "feat(dropbar): replace `path` with custom source"

### DIFF
--- a/lua/modules/configs/tool/dropbar.lua
+++ b/lua/modules/configs/tool/dropbar.lua
@@ -5,43 +5,20 @@ return function()
 		misc = require("modules.utils.icons").get("misc", true),
 		ui = require("modules.utils.icons").get("ui", true),
 	}
-	local utils = require("dropbar.utils")
-	local sources = require("dropbar.sources")
-	-- Custom source to display only the leaf filename in the dropbar
-	sources.symbols = {
-		get_symbols = function(buf, win, cursor)
-			local symbols = sources.path.get_symbols(buf, win, cursor)
-			return { symbols[#symbols] }
-		end,
-	}
 
 	require("modules.utils").load_plugin("dropbar", {
 		bar = {
 			hover = false,
 			truncate = true,
 			pick = { pivots = "etovxqpdygfblzhckisuran" },
-			sources = function(buf)
-				if vim.bo[buf].ft == "markdown" then
-					return {
-						sources.symbols,
-						sources.markdown,
-					}
-				end
-				if vim.bo[buf].buftype == "terminal" then
-					return {
-						sources.terminal,
-					}
-				end
-				return {
-					sources.symbols,
-					utils.source.fallback({
-						sources.lsp,
-						sources.treesitter,
-					}),
-				}
-			end,
 		},
 		sources = {
+			path = {
+				relative_to = function()
+					-- Only show the leaf filename in dropbar
+					return vim.fn.expand("%:p:h")
+				end,
+			},
 			terminal = {
 				name = function(buf)
 					local name = vim.api.nvim_buf_get_name(buf)


### PR DESCRIPTION
This patch revert #1430. This will cause inconvenience when open library file, make it hard to distinguish it with repo files.