### PR TITLE
fix(lualine): resolve background color defaulting issue

### DIFF
--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -98,12 +98,10 @@ return function()
 			if has_catppuccin then
 				return function()
 					local guifg = colors[fg]
-					local guibg = gen_bg and require("modules.utils").hl_to_rgb("StatusLine", true, colors.mantle)
-						or colors[bg]
 					local nobg = special_nobg and require("core.settings").transparent_background
 					return {
 						fg = guifg and guifg or colors.none,
-						bg = (guibg and not nobg) and guibg or colors.none,
+						bg = nobg and colors.none or ((not gen_bg and colors[bg]) or nil),
 						gui = gui and gui or nil,
 					}
 				end

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -161,10 +161,7 @@ function M.hl_to_rgb(hl_group, use_bg, fallback_hl)
 	local hlexists = pcall(vim.api.nvim_get_hl, 0, { name = hl_group, link = false })
 
 	if hlexists then
-		-- FIXME: Investigate why hl-StatusLine is undefined in toggleterm and remove this workaround
-		-- (@Jint-lzxy)
-		local link = vim.bo.filetype == "toggleterm"
-		local result = vim.api.nvim_get_hl(0, { name = hl_group, link = link })
+		local result = vim.api.nvim_get_hl(0, { name = hl_group, link = false })
 		if use_bg then
 			hex = result.bg and string.format("#%06x", result.bg) or "NONE"
 		else


### PR DESCRIPTION
This commit addresses the root cause of #1381 by allowing lualine to automatically select the default background color. Previously, lualine attempted to retrieve the background manually, which could lead to issues when querying in a different namespace (and resulting in an empty dictionary).