### PR TITLE
fix(keymap): prevent new builtins from interfering with our keymap

### DIFF
--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -42,7 +42,11 @@ function M.lsp(buf)
 		["n|gs"] = map_callback(function()
 			vim.lsp.buf.signature_help()
 		end):with_desc("lsp: Signature help"),
-		["n|gr"] = map_cr("Lspsaga rename"):with_silent():with_buffer(buf):with_desc("lsp: Rename in file range"),
+		["n|gr"] = map_cr("Lspsaga rename")
+			:with_silent()
+			:with_nowait()
+			:with_buffer(buf)
+			:with_desc("lsp: Rename in file range"),
 		["n|gR"] = map_cr("Lspsaga rename ++project")
 			:with_silent()
 			:with_buffer(buf)


### PR DESCRIPTION
This commit prevents lag when using `gr` by avoiding conflicts with new keymaps Neovim defines with this prefix.