### PR TITLE
feat: use tiny inline diagnostics to manage virtual text.

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -55,13 +55,7 @@ settings["server_formatting_block_list"] = {
 ---@type boolean
 settings["lsp_inlayhints"] = true
 
--- Set it to false if diagnostics virtual text is annoying.
--- If disabled, you may browse lsp diagnostics using trouble.nvim (press `gt` to toggle it).
----@type boolean
-settings["diagnostics_virtual_text"] = true
-
 -- Set it to false if diagnostics virtual lines is annoying.
--- NOTE: This entry is an alternative form to `diagnostics_virtual_text`.
 ---@type boolean
 settings["diagnostics_virtual_lines"] = false
 

--- a/lua/keymap/helpers.lua
+++ b/lua/keymap/helpers.lua
@@ -55,17 +55,6 @@ _G._toggle_inlayhint = function()
 end
 
 _G._toggle_virtualtext = function()
-	local _vt_enabled = require("core.settings").diagnostics_virtual_text
-	if _vt_enabled then
-		local vt_config = not vim.diagnostic.config().virtual_text
-		vim.diagnostic.config({ virtual_text = vt_config })
-		vim.notify(
-			(vt_config and "Virtual text is now displayed" or "Virtual text is now hidden"),
-			vim.log.levels.INFO,
-			{ title = "LSP Diagnostic" }
-		)
-	end
-
 	local _vl_enabled = require("core.settings").diagnostics_virtual_lines
 	if _vl_enabled then
 		local vl_config = not vim.diagnostic.config().virtual_lines

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 M.setup = function()
-	local diagnostics_virtual_text = require("core.settings").diagnostics_virtual_text
 	local diagnostics_virtual_lines = require("core.settings").diagnostics_virtual_lines
 	local diagnostics_level = require("core.settings").diagnostics_level
 
@@ -16,11 +15,7 @@ M.setup = function()
 	vim.diagnostic.config({
 		signs = true,
 		underline = false,
-		virtual_text = diagnostics_virtual_text and {
-			severity = {
-				min = vim.diagnostic.severity[diagnostics_level],
-			},
-		} or false,
+		virtual_text = false,
 		virtual_lines = diagnostics_virtual_lines and {
 			severity = {
 				min = vim.diagnostic.severity[diagnostics_level],

--- a/lua/modules/configs/completion/tiny-inline-diagnostic.lua
+++ b/lua/modules/configs/completion/tiny-inline-diagnostic.lua
@@ -1,0 +1,15 @@
+return function()
+	require("modules.utils").load_plugin("tiny-inline-diagnostic", {
+		preset = "modern",
+		options = {
+			show_source = {
+				enabled = true,
+				if_many = true,
+			},
+			use_icons_from_diagnostic = true,
+			break_line = {
+				enabled = true,
+			},
+		},
+	})
+end

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -44,6 +44,12 @@ completion["ayamir/garbage-day.nvim"] = {
 	event = "LspAttach",
 	config = require("completion.garbage-day"),
 }
+completion["rachartier/tiny-inline-diagnostic.nvim"] = {
+	lazy = true,
+	event = "VeryLazy",
+	priority = 1000, -- needs to be loaded in first
+	config = require("completion.tiny-inline-diagnostic"),
+}
 completion["hrsh7th/nvim-cmp"] = {
 	lazy = true,
 	event = "InsertEnter",


### PR DESCRIPTION
This PR remove the setting entry for virtual text b/c [tiny-inline-diagnostic.nvim](https://github.com/rachartier/tiny-inline-diagnostic.nvim) will manage it.

Effect:
Only show diagnostic message at current cursor position to avoid too many messages disrupt attention. We have `Trouble` and `g[`/`g]` to navigate between multiple diagnostic messages, so this is acceptable for me.

![image](https://github.com/user-attachments/assets/d3236669-2deb-4d9e-9fcd-2d53ee08beca)
