### PR TITLE
refactor: reintro aerial as symbol outline.

### DIFF
--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -27,6 +27,12 @@ function M.lsp(buf)
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline"),
+		["n|gto"] = map_callback(function()
+				require("telescope").extensions.aerial.aerial()
+			end)
+			:with_silent()
+			:with_buffer(buf)
+			:with_desc("lsp: Toggle outline in Telescope"),
 		["n|g["] = map_cr("Lspsaga diagnostic_jump_prev")
 			:with_silent()
 			:with_buffer(buf)

--- a/lua/modules/configs/completion/aerial.lua
+++ b/lua/modules/configs/completion/aerial.lua
@@ -1,0 +1,80 @@
+return function()
+	require("modules.utils").load_plugin("aerial", {
+		lazy_load = true,
+		close_on_select = false,
+		highlight_on_jump = true,
+		disable_max_lines = 8500,
+		disable_max_size = 1000000,
+		ignore = { filetypes = { "NvimTree", "terminal", "nofile" } },
+		-- Use symbol tree for folding. Set to true or false to enable/disable
+		-- Set to "auto" to manage folds if your previous foldmethod was 'manual'
+		-- This can be a filetype map (see :help aerial-filetype-map)
+		manage_folds = "auto",
+		layout = {
+			-- Determines the default direction to open the aerial window. The 'prefer'
+			-- options will open the window in the other direction *if* there is a
+			-- different buffer in the way of the preferred direction
+			-- Enum: prefer_right, prefer_left, right, left, float
+			default_direction = "prefer_right",
+		},
+		-- Keymaps in aerial window. Can be any value that `vim.keymap.set` accepts OR a table of keymap
+		-- options with a `callback` (e.g. { callback = function() ... end, desc = "", nowait = true })
+		-- Additionally, if it is a string that matches "actions.<name>",
+		-- it will use the mapping at require("aerial.actions").<name>
+		-- Set to `false` to remove a keymap
+		keymaps = {
+			["?"] = "actions.show_help",
+			["g?"] = "actions.show_help",
+			["<CR>"] = "actions.jump",
+			["<2-LeftMouse>"] = "actions.jump",
+			["<C-v>"] = "actions.jump_vsplit",
+			["<C-s>"] = "actions.jump_split",
+			["<C-d>"] = "actions.down_and_scroll",
+			["<C-u>"] = "actions.up_and_scroll",
+			["{"] = "actions.prev",
+			["}"] = "actions.next",
+			["[["] = "actions.prev_up",
+			["]]"] = "actions.next_up",
+			["q"] = "actions.close",
+			["o"] = "actions.tree_toggle",
+			["O"] = "actions.tree_toggle_recursive",
+			["zr"] = "actions.tree_increase_fold_level",
+			["zR"] = "actions.tree_open_all",
+			["zm"] = "actions.tree_decrease_fold_level",
+			["zM"] = "actions.tree_close_all",
+			["zx"] = "actions.tree_sync_folds",
+			["zX"] = "actions.tree_sync_folds",
+		},
+		-- A list of all symbols to display. Set to false to display all symbols.
+		-- This can be a filetype map (see :help aerial-filetype-map)
+		-- To see all available values, see :help SymbolKind
+		filter_kind = {
+			"Array",
+			"Boolean",
+			"Class",
+			"Constant",
+			"Constructor",
+			"Enum",
+			"EnumMember",
+			"Event",
+			"Field",
+			"File",
+			"Function",
+			"Interface",
+			"Key",
+			"Method",
+			"Module",
+			"Namespace",
+			"Null",
+			-- "Number",
+			"Object",
+			"Operator",
+			"Package",
+			-- "Property",
+			-- "String",
+			"Struct",
+			-- "TypeParameter",
+			-- "Variable",
+		},
+	})
+end

--- a/lua/modules/configs/tool/telescope.lua
+++ b/lua/modules/configs/tool/telescope.lua
@@ -44,6 +44,13 @@ return function()
 			buffer_previewer_maker = require("telescope.previewers").buffer_previewer_maker,
 		},
 		extensions = {
+			aerial = {
+				show_lines = false,
+				show_nesting = {
+					["_"] = false, -- This key will be the default
+					lua = true, -- You can set the option for specific filetypes
+				},
+			},
 			fzf = {
 				fuzzy = false,
 				override_generic_sorter = true,
@@ -82,6 +89,7 @@ return function()
 		},
 	})
 
+	require("telescope").load_extension("aerial")
 	require("telescope").load_extension("frecency")
 	require("telescope").load_extension("fzf")
 	require("telescope").load_extension("live_grep_args")

--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -34,8 +34,8 @@ return function()
 					padding = 0,
 				},
 				{
-					filetype = "trouble",
-					text = "LSP Outline",
+					filetype = "aerial",
+					text = "Symbol Outline",
 					text_align = "center",
 					padding = 0,
 				},

--- a/lua/modules/configs/ui/catppuccin.lua
+++ b/lua/modules/configs/ui/catppuccin.lua
@@ -30,6 +30,7 @@ return function()
 			properties = {},
 		},
 		integrations = {
+			aerial = true,
 			cmp = true,
 			dap = true,
 			dap_ui = true,

--- a/lua/modules/configs/ui/edgy.lua
+++ b/lua/modules/configs/ui/edgy.lua
@@ -57,19 +57,9 @@ return function()
 		},
 		right = {
 			{
-				ft = "trouble",
+				ft = "aerial",
 				pinned = true,
-				size = { height = 0.6, width = 0.3 },
-				open = "Trouble symbols toggle win.position=right",
-				filter = trouble_filter("right"),
-			},
-			{
-				ft = "trouble",
-				pinned = true,
-				collapsed = true,
-				size = { height = 0.4, width = 0.3 },
-				open = "Trouble lsp toggle win.position=right",
-				filter = trouble_filter("right"),
+				open = "AerialToggle!",
 			},
 		},
 	})

--- a/lua/modules/configs/ui/edgy.lua
+++ b/lua/modules/configs/ui/edgy.lua
@@ -1,14 +1,4 @@
 return function()
-	local trouble_filter = function(position)
-		return function(_, win)
-			return vim.w[win].trouble
-				and vim.w[win].trouble.position == position
-				and vim.w[win].trouble.type == "split"
-				and vim.w[win].trouble.relative == "editor"
-				and not vim.w[win].trouble_preview
-		end
-	end
-
 	require("modules.utils").load_plugin("edgy", {
 		close_when_all_hidden = true,
 		exit_when_last = true,

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -21,6 +21,11 @@ completion["nvimdev/lspsaga.nvim"] = {
 	config = require("completion.lspsaga"),
 	dependencies = { "nvim-tree/nvim-web-devicons" },
 }
+completion["stevearc/aerial.nvim"] = {
+	lazy = true,
+	event = "LspAttach",
+	config = require("completion.aerial"),
+}
 completion["DNLHC/glance.nvim"] = {
 	lazy = true,
 	event = "LspAttach",


### PR DESCRIPTION
Reason: https://github.com/ayamir/nvimdots/discussions/494#discussioncomment-12925108

This pr a is partially revert of #1393, `Trouble lsp` is removed due to we ofter use `gh` to check lsp reference, this window is not helpful enough.