### PR TITLE
refactor(mason): support for mason and mason-lspconfig v2

### DIFF
--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -3,13 +3,11 @@ local M = {}
 M.setup = function()
 	local diagnostics_virtual_lines = require("core.settings").diagnostics_virtual_lines
 	local diagnostics_level = require("core.settings").diagnostics_level
+	local lsp_deps = require("core.settings").lsp_deps
 
-	local nvim_lsp = require("lspconfig")
-	local mason_lspconfig = require("mason-lspconfig")
 	require("lspconfig.ui.windows").default_options.border = "rounded"
-
 	require("modules.utils").load_plugin("mason-lspconfig", {
-		ensure_installed = require("core.settings").lsp_deps,
+		ensure_installed = lsp_deps,
 	})
 
 	vim.diagnostic.config({
@@ -61,15 +59,17 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 
 		if not ok then
 			-- Default to use factory config for server(s) that doesn't include a spec
-			nvim_lsp[lsp_name].setup(opts)
-			return
+			vim.lsp.config(lsp_name, opts)
+			vim.lsp.enable(lsp_name)
 		elseif type(custom_handler) == "function" then
 			--- Case where language server requires its own setup
 			--- Make sure to call require("lspconfig")[lsp_name].setup() in the function
 			--- See `clangd.lua` for example.
 			custom_handler(opts)
+			vim.lsp.enable(lsp_name)
 		elseif type(custom_handler) == "table" then
-			nvim_lsp[lsp_name].setup(
+			vim.lsp.config(
+				lsp_name,
 				vim.tbl_deep_extend(
 					"force",
 					opts,
@@ -77,6 +77,7 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 					custom_handler
 				)
 			)
+			vim.lsp.enable(lsp_name)
 		else
 			vim.notify(
 				string.format(
@@ -88,9 +89,12 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 				{ title = "nvim-lspconfig" }
 			)
 		end
+		return
 	end
 
-	mason_lspconfig.setup_handlers({ mason_lsp_handler })
+	for _, lsp in ipairs(lsp_deps) do
+		mason_lsp_handler(lsp)
+	end
 end
 
 return M

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -6,8 +6,8 @@ completion["neovim/nvim-lspconfig"] = {
 	event = { "CursorHold", "CursorHoldI" },
 	config = require("completion.lsp"),
 	dependencies = {
-		{ "williamboman/mason.nvim", version = "1.11.0" },
-		{ "williamboman/mason-lspconfig.nvim", version = "1.32.0" },
+		{ "mason-org/mason.nvim" },
+		{ "mason-org/mason-lspconfig.nvim" },
 		{ "folke/neoconf.nvim" },
 		{
 			"Jint-lzxy/lsp_signature.nvim",


### PR DESCRIPTION
- fix ayamir/nvimdots#1461

Having reviewed the [release note](https://github.com/mason-org/mason-lspconfig.nvim/releases/tag/v2.0.0), it appears we can support the new API without significant changes to the existing code. 
This provides a base for considering v2 support.

Currently, we provide our own handlers, but we could leverage [Neovim's](https://neovim.io/doc/user/lsp.html) [built-in mechanism](https://neovim.io/doc/user/options.html#after-directory) for this.
Specifically, we can create a file at `after/lsp/<lsp-name>.lua` within the project root. In my local environment, this allowed me to override the LSP settings.
However, this approach might make it more difficult to separate user configurations from the repository's defaults.