### PR TITLE
refactor: introduce fzf-lua as an alternative of telescope.

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -221,4 +221,10 @@ settings["dashboard_image"] = {
 	[[⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠛⢿⣿⣿⠂⠀⠀⠀⠀⠀⢀⣽⣿⣿⣿⣿⣿⣿⣿⣍⠛⠿⣿⣿⣿⣿⣿⣿]],
 }
 
+-- Set the search backend to use here.
+-- telescope is enough for most cases.
+-- fzf is more powerful for searching in huge repo but needs fzf binary installed.
+---@type "telescope"|"fzf"
+settings["search_backend"] = "telescope"
+
 return require("modules.utils").extend_config(settings, "user.settings")

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -25,7 +25,7 @@ function M.lsp(buf)
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline"),
-		["n|gto"] = map_cr("Telescope lsp_document_symbols")
+		["n|gto"] = map_cr("FzfLua lsp_document_symbols")
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline in Telescope"),

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -25,7 +25,12 @@ function M.lsp(buf)
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline"),
-		["n|gto"] = map_cr("FzfLua lsp_document_symbols")
+		["n|gto"] = map_callback(function()
+				local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
+				require("fzf-lua").lsp_document_symbols({
+					fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" },
+				})
+			end)
 			:with_silent()
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline in Telescope"),

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -26,10 +26,15 @@ function M.lsp(buf)
 			:with_buffer(buf)
 			:with_desc("lsp: Toggle outline"),
 		["n|gto"] = map_callback(function()
-				local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
-				require("fzf-lua").lsp_document_symbols({
-					fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" },
-				})
+				local search_backend = require("core.settings").search_backend
+				if search_backend == "fzf" then
+					local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
+					require("fzf-lua").lsp_document_symbols({
+						fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" },
+					})
+				else
+					require("telescope.builtin").lsp_document_symbols()
+				end
 			end)
 			:with_silent()
 			:with_buffer(buf)

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -132,14 +132,21 @@ local mappings = {
 			:with_silent()
 			:with_desc("tool: Find patterns"),
 		["v|<leader>fs"] = map_callback(function()
-				local default_opts = "--column --line-number --no-heading --color=always --smart-case"
-				local opts = vim.fn.getcwd() == vim_path and default_opts .. " --no-ignore --hidden --glob '!.git/*'"
-					or ""
-				local text = require("fzf-lua.utils").get_visual_selection()
-				require("fzf-lua").grep_project({
-					search = text,
-					rg_opts = opts,
-				})
+				local search_backend = require("core.settings").search_backend
+				if search_backend == "fzf" then
+					local default_opts = "--column --line-number --no-heading --color=always --smart-case"
+					local opts = vim.fn.getcwd() == vim_path
+							and default_opts .. " --no-ignore --hidden --glob '!.git/*'"
+						or ""
+					local text = require("fzf-lua.utils").get_visual_selection()
+					require("fzf-lua").grep_project({
+						search = text,
+						rg_opts = opts,
+					})
+				else
+					local opts = vim.fn.getcwd() == vim_path and { additional_args = { "--no-ignore" } } or {}
+					require("telescope-live-grep-args.shortcuts").grep_visual_selection(opts)
+				end
 			end)
 			:with_noremap()
 			:with_silent()

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -99,12 +99,7 @@ local mappings = {
 			:with_desc("lsp: Show document diagnostics"),
 
 		-- Plugin: telescope
-		["n|<C-p>"] = map_callback(function()
-				_command_panel()
-			end)
-			:with_noremap()
-			:with_silent()
-			:with_desc("tool: Toggle command panel"),
+		["n|<C-p>"] = map_cr("FzfLua keymaps"):with_noremap():with_silent():with_desc("tool: Toggle command panel"),
 		["n|<leader>fc"] = map_callback(function()
 				_telescope_collections(require("telescope.themes").get_dropdown())
 			end)
@@ -124,8 +119,14 @@ local mappings = {
 			:with_silent()
 			:with_desc("tool: Find patterns"),
 		["v|<leader>fs"] = map_callback(function()
-				local opts = vim.fn.getcwd() == vim_path and { additional_args = { "--no-ignore" } } or {}
-				require("telescope-live-grep-args.shortcuts").grep_visual_selection(opts)
+				local default_opts = "--column --line-number --no-heading --color=always --smart-case"
+				local opts = vim.fn.getcwd() == vim_path and default_opts .. " --no-ignore --hidden --glob '!.git/*'"
+					or ""
+				local text = require("fzf-lua.utils").get_visual_selection()
+				require("fzf-lua").grep_project({
+					search = text,
+					rg_opts = opts,
+				})
 			end)
 			:with_noremap()
 			:with_silent()

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -99,7 +99,20 @@ local mappings = {
 			:with_desc("lsp: Show document diagnostics"),
 
 		-- Plugin: telescope
-		["n|<C-p>"] = map_cr("FzfLua keymaps"):with_noremap():with_silent():with_desc("tool: Toggle command panel"),
+		["n|<C-p>"] = map_callback(function()
+				local search_backend = require("core.settings").search_backend
+				if search_backend == "fzf" then
+					local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
+					require("fzf-lua").keymaps({
+						fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" },
+					})
+				else
+					_command_panel()
+				end
+			end)
+			:with_noremap()
+			:with_silent()
+			:with_desc("tool: Toggle command panel"),
 		["n|<leader>fc"] = map_callback(function()
 				_telescope_collections(require("telescope.themes").get_dropdown())
 			end)

--- a/lua/keymap/tool.lua
+++ b/lua/keymap/tool.lua
@@ -173,6 +173,15 @@ local mappings = {
 			:with_noremap()
 			:with_silent()
 			:with_desc("tool: Resume last search"),
+		["n|<leader>fR"] = map_callback(function()
+				local search_backend = require("core.settings").search_backend
+				if search_backend == "fzf" then
+					require("fzf-lua").resume()
+				end
+			end)
+			:with_noremap()
+			:with_silent()
+			:with_desc("tool: Resume last search"),
 
 		-- Plugin: dap
 		["n|<F6>"] = map_callback(function()

--- a/lua/modules/configs/tool/fzf-lua.lua
+++ b/lua/modules/configs/tool/fzf-lua.lua
@@ -1,5 +1,10 @@
 return function()
+	local icons = { ui = require("modules.utils.icons").get("ui", true) }
+
 	require("modules.utils").load_plugin("fzf-lua", {
 		{ "telescope" },
+		defaults = {
+			prompt = icons.ui.Telescope .. " ",
+		},
 	})
 end

--- a/lua/modules/configs/tool/fzf-lua.lua
+++ b/lua/modules/configs/tool/fzf-lua.lua
@@ -1,0 +1,5 @@
+return function()
+	require("modules.utils").load_plugin("fzf-lua", {
+		{ "telescope" },
+	})
+end

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -1,9 +1,18 @@
 return function()
+	local fzf = require("fzf-lua")
 	local builtin = require("telescope.builtin")
 	local extensions = require("telescope").extensions
 	local vim_path = require("core.global").vim_path
+	local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
+	local fzf_opts = { fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" } }
 
 	require("modules.utils").load_plugin("search", {
+		prompt_position = prompt_position,
+		engine = "fzf",
+		mappings = {
+			next = "<A-i>",
+			prev = "<A-o>",
+		},
 		collections = {
 			-- Search using filenames
 			file = {
@@ -11,33 +20,32 @@ return function()
 				tabs = {
 					{
 						name = "Files",
-						tele_func = function(opts)
-							opts = opts or {}
-							if vim.fn.getcwd() == vim_path then
-								builtin.find_files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
-							elseif vim.fn.isdirectory(".git") == 1 then
-								builtin.git_files(opts)
-							else
-								builtin.find_files(opts)
-							end
-						end,
-					},
-					{
-						name = "Frecency",
 						tele_func = function()
-							extensions.frecency.frecency()
+							local opts = {}
+							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+							if vim.fn.getcwd() == vim_path then
+								fzf.files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
+							elseif vim.fn.isdirectory(".git") == 1 then
+								fzf.git_files(opts)
+							else
+								fzf.files(opts)
+							end
 						end,
 					},
 					{
 						name = "Oldfiles",
 						tele_func = function()
-							builtin.oldfiles()
+							local opts = {}
+							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+							fzf.oldfiles(opts)
 						end,
 					},
 					{
 						name = "Buffers",
 						tele_func = function()
-							builtin.buffers()
+							local opts = {}
+							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+							fzf.buffers(opts)
 						end,
 					},
 				},
@@ -50,20 +58,22 @@ return function()
 						name = "Word in project",
 						tele_func = function()
 							local opts = {}
+							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 							if vim.fn.getcwd() == vim_path then
-								opts["additional_args"] = { "--no-ignore" }
+								opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
 							end
-							extensions.live_grep_args.live_grep_args(opts)
+							fzf.live_grep(opts)
 						end,
 					},
 					{
 						name = "Word under cursor",
-						tele_func = function(opts)
-							opts = opts or {}
+						tele_func = function()
+							local opts = {}
+							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 							if vim.fn.getcwd() == vim_path then
-								opts["additional_args"] = { "--no-ignore" }
+								opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
 							end
-							builtin.grep_string(opts)
+							fzf.grep_cword(opts)
 						end,
 					},
 				},

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -8,11 +8,6 @@ return function()
 
 	require("modules.utils").load_plugin("search", {
 		prompt_position = prompt_position,
-		engine = "fzf",
-		mappings = {
-			next = "<A-i>",
-			prev = "<A-o>",
-		},
 		collections = {
 			-- Search using filenames
 			file = {

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -1,10 +1,94 @@
 return function()
+	local search_backend = require("core.settings").search_backend
 	local fzf = require("fzf-lua")
 	local builtin = require("telescope.builtin")
 	local extensions = require("telescope").extensions
 	local vim_path = require("core.global").vim_path
 	local prompt_position = require("telescope.config").values.layout_config.horizontal.prompt_position
 	local fzf_opts = { fzf_opts = { ["--layout"] = prompt_position == "top" and "reverse" or "default" } }
+	local files = function()
+		if search_backend == "fzf" then
+			return function()
+				local opts = {}
+				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+				if vim.fn.getcwd() == vim_path then
+					fzf.files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
+				elseif vim.fn.isdirectory(".git") == 1 then
+					fzf.git_files(opts)
+				else
+					fzf.files(opts)
+				end
+			end
+		else
+			return function(opts)
+				opts = opts or {}
+				if vim.fn.getcwd() == vim_path then
+					builtin.find_files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
+				elseif vim.fn.isdirectory(".git") == 1 then
+					builtin.git_files(opts)
+				else
+					builtin.find_files(opts)
+				end
+			end
+		end
+	end
+
+	local old_files = function()
+		if search_backend == "fzf" then
+			return function()
+				local opts = {}
+				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+				fzf.oldfiles(opts)
+			end
+		else
+			return function(opts)
+				opts = opts or {}
+				builtin.oldfiles(opts)
+			end
+		end
+	end
+
+	local word_in_project = function()
+		if search_backend == "fzf" then
+			return function()
+				local opts = {}
+				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+				if vim.fn.getcwd() == vim_path then
+					opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
+				end
+				fzf.live_grep(opts)
+			end
+		else
+			return function(opts)
+				opts = opts or {}
+				if vim.fn.getcwd() == vim_path then
+					opts["additional_args"] = { "--no-ignore" }
+				end
+				extensions.live_grep_args.live_grep_args(opts)
+			end
+		end
+	end
+
+	local word_under_cursor = function()
+		if search_backend == "fzf" then
+			return function()
+				local opts = {}
+				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
+				if vim.fn.getcwd() == vim_path then
+					opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
+				end
+				fzf.grep_cword(opts)
+			end
+		else
+			return function(opts)
+				opts = opts or {}
+				if vim.fn.getcwd() == vim_path then
+					opts["additional_args"] = { "--no-ignore" }
+				end
+				builtin.grep_string(opts)
+			end
+		end
+	end
 
 	require("modules.utils").load_plugin("search", {
 		prompt_position = prompt_position,
@@ -15,17 +99,7 @@ return function()
 				tabs = {
 					{
 						name = "Files",
-						tele_func = function()
-							local opts = {}
-							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
-							if vim.fn.getcwd() == vim_path then
-								fzf.files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
-							elseif vim.fn.isdirectory(".git") == 1 then
-								fzf.git_files(opts)
-							else
-								fzf.files(opts)
-							end
-						end,
+						tele_func = files(),
 					},
 					{
 						name = "Frecency",
@@ -35,11 +109,7 @@ return function()
 					},
 					{
 						name = "Oldfiles",
-						tele_func = function()
-							local opts = {}
-							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
-							fzf.oldfiles(opts)
-						end,
+						tele_func = old_files(),
 					},
 					{
 						name = "Buffers",
@@ -55,25 +125,11 @@ return function()
 				tabs = {
 					{
 						name = "Word in project",
-						tele_func = function()
-							local opts = {}
-							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
-							if vim.fn.getcwd() == vim_path then
-								opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
-							end
-							fzf.live_grep(opts)
-						end,
+						tele_func = word_in_project(),
 					},
 					{
 						name = "Word under cursor",
-						tele_func = function()
-							local opts = {}
-							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
-							if vim.fn.getcwd() == vim_path then
-								opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
-							end
-							fzf.grep_cword(opts)
-						end,
+						tele_func = word_under_cursor(),
 					},
 				},
 			},

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -44,9 +44,7 @@ return function()
 					{
 						name = "Buffers",
 						tele_func = function()
-							local opts = {}
-							opts = vim.tbl_deep_extend("force", opts, fzf_opts)
-							fzf.buffers(opts)
+							builtin.buffers()
 						end,
 					},
 				},

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -1,6 +1,5 @@
 return function()
 	local search_backend = require("core.settings").search_backend
-	local fzf = require("fzf-lua")
 	local builtin = require("telescope.builtin")
 	local extensions = require("telescope").extensions
 	local vim_path = require("core.global").vim_path
@@ -10,6 +9,7 @@ return function()
 		if search_backend == "fzf" then
 			return function()
 				local opts = {}
+				local fzf = require("fzf-lua")
 				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 				if vim.fn.getcwd() == vim_path then
 					fzf.files(vim.tbl_deep_extend("force", opts, { no_ignore = true }))
@@ -37,6 +37,7 @@ return function()
 		if search_backend == "fzf" then
 			return function()
 				local opts = {}
+				local fzf = require("fzf-lua")
 				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 				fzf.oldfiles(opts)
 			end
@@ -52,6 +53,7 @@ return function()
 		if search_backend == "fzf" then
 			return function()
 				local opts = {}
+				local fzf = require("fzf-lua")
 				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 				if vim.fn.getcwd() == vim_path then
 					opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })
@@ -73,6 +75,7 @@ return function()
 		if search_backend == "fzf" then
 			return function()
 				local opts = {}
+				local fzf = require("fzf-lua")
 				opts = vim.tbl_deep_extend("force", opts, fzf_opts)
 				if vim.fn.getcwd() == vim_path then
 					opts = vim.tbl_deep_extend("force", opts, { no_ignore = true })

--- a/lua/modules/configs/tool/search.lua
+++ b/lua/modules/configs/tool/search.lua
@@ -28,6 +28,12 @@ return function()
 						end,
 					},
 					{
+						name = "Frecency",
+						tele_func = function()
+							extensions.frecency.frecency()
+						end,
+					},
+					{
 						name = "Oldfiles",
 						tele_func = function()
 							local opts = {}

--- a/lua/modules/configs/tool/telescope.lua
+++ b/lua/modules/configs/tool/telescope.lua
@@ -25,7 +25,6 @@ return function()
 			file_ignore_patterns = { ".git/", ".cache", "build/", "%.class", "%.pdf", "%.mkv", "%.mp4", "%.zip" },
 			layout_config = {
 				horizontal = {
-					prompt_position = "top",
 					preview_width = 0.55,
 					results_width = 0.8,
 				},

--- a/lua/modules/configs/tool/telescope.lua
+++ b/lua/modules/configs/tool/telescope.lua
@@ -17,16 +17,14 @@ return function()
 			selection_caret = icons.ui.ChevronRight,
 			scroll_strategy = "limit",
 			results_title = false,
-			layout_strategy = "horizontal",
+			layout_strategy = "flex",
 			path_display = { "absolute" },
 			selection_strategy = "reset",
-			sorting_strategy = "ascending",
 			color_devicons = true,
 			file_ignore_patterns = { ".git/", ".cache", "build/", "%.class", "%.pdf", "%.mkv", "%.mp4", "%.zip" },
 			layout_config = {
 				horizontal = {
 					preview_width = 0.55,
-					results_width = 0.8,
 				},
 				vertical = {
 					mirror = false,

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -93,7 +93,7 @@ tool["nvim-telescope/telescope.nvim"] = {
 		{ "nvim-telescope/telescope-live-grep-args.nvim" },
 		{ "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
 		{
-			"FabianWirth/search.nvim",
+			"ayamir/search.nvim",
 			config = require("tool.search"),
 		},
 		{

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -72,6 +72,11 @@ tool["gelguy/wilder.nvim"] = {
 	dependencies = { "romgrk/fzy-lua-native" },
 }
 
+tool["ibhagwan/fzf-lua"] = {
+	lazy = true,
+	event = "VeryLazy",
+	config = require("tool.fzf-lua"),
+}
 ----------------------------------------------------------------------
 --                        Telescope Plugins                         --
 ----------------------------------------------------------------------

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -1,4 +1,5 @@
 local tool = {}
+local settings = require("core.settings")
 
 tool["tpope/vim-fugitive"] = {
 	lazy = true,
@@ -71,12 +72,15 @@ tool["gelguy/wilder.nvim"] = {
 	config = require("tool.wilder"),
 	dependencies = { "romgrk/fzy-lua-native" },
 }
+if settings.search_backend == "fzf" then
+	-- require fzf binary installed
+	tool["ibhagwan/fzf-lua"] = {
+		lazy = true,
+		event = "VeryLazy",
+		config = require("tool.fzf-lua"),
+	}
+end
 
-tool["ibhagwan/fzf-lua"] = {
-	lazy = true,
-	event = "VeryLazy",
-	config = require("tool.fzf-lua"),
-}
 ----------------------------------------------------------------------
 --                        Telescope Plugins                         --
 ----------------------------------------------------------------------


### PR DESCRIPTION
This pr introduce `fzf-lua` as fuzzy searcher to replace part functionalies of `telescope.nvim` to achieve higher performance when search in a big repo. I forked and rewrote `search.nvim` to make it support `fzf-lua`. Not all pickers are equivalent such as frecency and not all pickers are replaced, but now it basically works. It will close #1463.

https://github.com/user-attachments/assets/abb2d597-b856-4085-a516-7c893609961e

@Elite-zx You can try it now.