### PR TITLE
fixup(#1466): load lsp config with proper event.

### DIFF
--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -89,7 +89,6 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 				{ title = "nvim-lspconfig" }
 			)
 		end
-		return
 	end
 
 	for _, lsp in ipairs(lsp_deps) do

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -3,7 +3,7 @@ local use_copilot = require("core.settings").use_copilot
 
 completion["neovim/nvim-lspconfig"] = {
 	lazy = true,
-	event = { "CursorHold", "CursorHoldI" },
+	event = { "BufReadPre", "BufNewFile" },
 	config = require("completion.lsp"),
 	dependencies = {
 		{ "mason-org/mason.nvim" },


### PR DESCRIPTION
This path change the lazy load event of `nvim-lspconfig` to `BufReadPre` and `BufNewFile`, to resolve the issue that the lsp servers don't autostart.