### PR TITLE
fix: install rainbow-delimiters.nvim without cloning submodules.

### DIFF
--- a/lua/modules/plugins/editor.lua
+++ b/lua/modules/plugins/editor.lua
@@ -113,6 +113,7 @@ editor["nvim-treesitter/nvim-treesitter"] = {
 		},
 		{
 			"hiphish/rainbow-delimiters.nvim",
+			submodules = false,
 			config = require("editor.rainbow_delims"),
 		},
 		{


### PR DESCRIPTION
This PR adds `submodule=false` in `rainbow-delimiters.nvim` installation config.

Sometimes I encountered an error while updating `rainbow-delimiters.nvim`. The error indicated that some submodules are not found. So I check the plugin, the [README](https://github.com/HiPhish/rainbow-delimiters.nvim?tab=readme-ov-file#installation) says:

> you do not need the Git submodules of this repository. They are just used for development and won't cause any harm, they will just bloat your setup.

And I found the `bin` submodule in the [test directory](https://github.com/HiPhish/rainbow-delimiters.nvim/tree/master/test) cannot be reached, which might be a cause. Although I'm not sure if the updating error always happens, it's safe to remove these submodules.