### PR TITLE
feat: add discord and deepwiki, change badge style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,44 @@
 <h1 align="center">
     nvimdots
-    <br>
-    <a href="https://github.com/neovim/neovim/releases/tag/stable">
-    <img
-        alt="Neovim Version Capability"
-        src="https://img.shields.io/badge/Supports%20Nvim-v0.11-A6D895?style=for-the-badge&colorA=363A4F&logo=neovim&logoColor=D9E0EE">
-    </a>
-    <a href="https://github.com/ayamir/nvimdots/releases">
-    <img
-        alt="Release"
-        src="https://img.shields.io/github/v/release/ayamir/nvimdots.svg?style=for-the-badge&logo=github&color=F2CDCD&logoColor=D9E0EE&labelColor=363A4F">
-    </a>
 </h1>
 
-<p align="center">
-    <a href="https://github.com/ayamir/nvimdots/stargazers">
+<div align="center">
     <img
         alt="Stars"
-        src="https://img.shields.io/github/stars/ayamir/nvimdots?colorA=363A4F&colorB=B7BDF8&logo=adafruit&logoColor=D9E0EE&style=for-the-badge">
+        src="https://img.shields.io/github/stars/ayamir/nvimdots?colorA=363A4F&colorB=B7BDF8&logo=adafruit&logoColor=D9E0EE">
     </a>
     <a href="https://github.com/ayamir/nvimdots/issues">
     <img
         alt="Issues"
-        src="https://img.shields.io/github/issues-raw/ayamir/nvimdots?colorA=363A4f&colorB=F5A97F&logo=github&logoColor=D9E0EE&style=for-the-badge">
+        src="https://img.shields.io/github/issues-raw/ayamir/nvimdots?colorA=363A4f&colorB=F5A97F&logo=github&logoColor=D9E0EE">
     </a>
+    <a href="https://github.com/neovim/neovim/releases/tag/stable">
+    <img
+        alt="Neovim Version Capability"
+        src="https://img.shields.io/badge/Supports%20Nvim-v0.11-A6D895?colorA=363A4F&logo=neovim&logoColor=D9E0EE">
+    </a>
+    <a href="https://github.com/ayamir/nvimdots/releases">
+    <img
+        alt="Release"
+        src="https://img.shields.io/github/v/release/ayamir/nvimdots.svg?logo=github&color=F2CDCD&logoColor=D9E0EE&labelColor=363A4F">
+    </a>
+    <a href="https://github.com/ayamir/nvimdots/stargazers">
+    <br>
     <a href="https://github.com/ayamir/nvimdots/contributors">
     <img
         alt="Contributors"
-        src="https://img.shields.io/github/contributors/ayamir/nvimdots?colorA=363A4F&colorB=B5E8E0&logo=git&logoColor=D9E0EE&style=for-the-badge">
+        src="https://img.shields.io/github/contributors/ayamir/nvimdots?colorA=363A4F&colorB=B5E8E0&logo=git&logoColor=D9E0EE">
     </a>
     <img
         alt="Code Size"
-        src="https://img.shields.io/github/languages/code-size/ayamir/nvimdots?colorA=363A4F&colorB=DDB6F2&logo=gitlfs&logoColor=D9E0EE&style=for-the-badge">
-</p>
+        src="https://img.shields.io/github/languages/code-size/ayamir/nvimdots?colorA=363A4F&colorB=DDB6F2&logo=gitlfs&logoColor=D9E0EE">
+    <a href="https://discord.gg/jAYvWRbTRU">
+    <img
+        alt="Discord"
+        src="https://img.shields.io/badge/Discord-nvimdots-b4befe?colorA=363A4F&logo=discord&logoColor=D9E0EE"/>
+    </a>
+    <a href="https://deepwiki.com/ayamir/nvimdots"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+</div>
 
 ## 🪷 Introduction
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
     <img
         alt="Code Size"
         src="https://img.shields.io/github/languages/code-size/ayamir/nvimdots?colorA=363A4F&colorB=DDB6F2&logo=gitlfs&logoColor=D9E0EE">
-    <a href="https://discord.gg/jAYvWRbTRU">
+    <a href="https://discord.gg/rE46YdFAUc">
     <img
         alt="Discord"
         src="https://img.shields.io/badge/Discord-nvimdots-b4befe?colorA=363A4F&logo=discord&logoColor=D9E0EE"/>


### PR DESCRIPTION
This commit add discord and deepwiki for nvimdots. The badge style is changed to normal for compatible with new added deepwiki badge.
![image](https://github.com/user-attachments/assets/997a5b2a-04ea-4a95-a32b-f897426aa96d)
