### PR TITLE
fix(dap): deprecate `Package:get_install_path()`

### DIFF
--- a/lua/modules/configs/tool/dap/clients/delve.lua
+++ b/lua/modules/configs/tool/dap/clients/delve.lua
@@ -26,8 +26,7 @@ return function()
 		type = "executable",
 		command = "node",
 		args = {
-			require("mason-registry").get_package("go-debug-adapter"):get_install_path()
-				.. "/extension/dist/debugAdapter.js",
+			vim.fn.expand("$MASON") .. "/packages/go-debug-adapter" .. "/extension/dist/debugAdapter.js",
 		},
 	}
 	dap.configurations.go = {

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -4,7 +4,7 @@ return function()
 	local dap = require("dap")
 	local utils = require("modules.utils.dap")
 	local is_windows = require("core.global").is_windows
-	local debugpy_root = require("mason-registry").get_package("debugpy"):get_install_path()
+	local debugpy_root = vim.fn.expand("$MASON") .. "/packages/debugpy"
 
 	dap.adapters.python = function(callback, config)
 		if config.request == "attach" then


### PR DESCRIPTION
https://github.com/mason-org/mason.nvim/blob/7c7318e8bae7e3536ef6b9e86b9e38e74f2e125e/CHANGELOG.md?plain=1#L65