### PR TITLE
refactor(lsp): consistently use tiny-inline-diagnostic API

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lunarmodules/luacheck@v1
         with:
-          args: . --std luajit --max-line-length 150 --no-config --globals vim _debugging _command_panel _flash_esc_or_noh _telescope_collections _toggle_inlayhint _toggle_virtualtext  _toggle_lazygit _select_chat_model
+          args: . --std luajit --max-line-length 150 --no-config --globals vim _debugging _command_panel _flash_esc_or_noh _telescope_collections _toggle_inlayhint _toggle_virtuallines _toggle_lazygit _select_chat_model

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -60,7 +60,7 @@ settings["diagnostics_virtual_lines"] = true
 -- Set the minimum severity level of diagnostics to display.
 -- Priority: `Error` > `Warning` > `Information` > `Hint`.
 -- For example, if set to `Warning`, only warnings and errors will be shown.
--- NOTE: This only works when `diagnostics_virtual_text` is true.
+-- NOTE: This only works when `diagnostics_virtual_lines` is true.
 ---@type "ERROR"|"WARN"|"INFO"|"HINT"
 settings["diagnostics_level"] = "HINT"
 

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -52,10 +52,10 @@ settings["format_disabled_dirs"] = {
 	"~/format_disabled_dir",
 }
 
--- Set to false to disable diagnostic virtual lines.
--- If disabled, use trouble.nvim to view diagnostics (press `<leader>ld` to toggle).
+-- Set to false to disable virtual lines for diagnostics.
+-- You can still view diagnostics using trouble.nvim (`<leader>ld`).
 ---@type boolean
-settings["diagnostics_virtual_lines"] = false
+settings["diagnostics_virtual_lines"] = true
 
 -- Set the minimum severity level of diagnostics to display.
 -- Priority: `Error` > `Warning` > `Information` > `Hint`.

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -84,7 +84,7 @@ function M.lsp(buf)
 			:with_buffer(buf)
 			:with_desc("lsp: Show outgoing calls"),
 		["n|<leader>lv"] = map_callback(function()
-				_toggle_virtualtext()
+				_toggle_virtuallines()
 			end)
 			:with_noremap()
 			:with_silent()

--- a/lua/keymap/completion.lua
+++ b/lua/keymap/completion.lua
@@ -88,13 +88,13 @@ function M.lsp(buf)
 			end)
 			:with_noremap()
 			:with_silent()
-			:with_desc("lsp: Toggle virtual text display"),
+			:with_desc("lsp: Toggle virtual lines"),
 		["n|<leader>lh"] = map_callback(function()
 				_toggle_inlayhint()
 			end)
 			:with_noremap()
 			:with_silent()
-			:with_desc("lsp: Toggle inlay hints display"),
+			:with_desc("lsp: Toggle inlay hints"),
 	}
 	bind.nvim_load_mapping(map)
 

--- a/lua/keymap/helpers.lua
+++ b/lua/keymap/helpers.lua
@@ -55,17 +55,14 @@ _G._toggle_inlayhint = function()
 	)
 end
 
-_G._toggle_virtualtext = function()
-	local _vl_enabled = require("core.settings").diagnostics_virtual_lines
-	if _vl_enabled then
-		local vl_config = not vim.diagnostic.config().virtual_lines
-		vim.diagnostic.config({ virtual_lines = vl_config })
-		vim.notify(
-			(vl_config and "Virtual lines is now displayed" or "Virtual lines is now hidden"),
-			vim.log.levels.INFO,
-			{ title = "LSP Diagnostic" }
-		)
-	end
+_G._toggle_virtuallines = function()
+	require("tiny-inline-diagnostic").toggle()
+	vim.notify(
+		"Virtual lines are now "
+			.. (require("tiny-inline-diagnostic.diagnostic").user_toggle_state and "displayed" or "hidden"),
+		vim.log.levels.INFO,
+		{ title = "LSP Diagnostic" }
+	)
 end
 
 local _lazygit = nil

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -1,8 +1,6 @@
 local M = {}
 
 M.setup = function()
-	local diagnostics_virtual_lines = require("core.settings").diagnostics_virtual_lines
-	local diagnostics_level = require("core.settings").diagnostics_level
 	local lsp_deps = require("core.settings").lsp_deps
 
 	require("lspconfig.ui.windows").default_options.border = "rounded"
@@ -12,14 +10,8 @@ M.setup = function()
 
 	vim.diagnostic.config({
 		signs = true,
-		underline = false,
+		underline = true,
 		virtual_text = false,
-		virtual_lines = diagnostics_virtual_lines and {
-			severity = {
-				min = vim.diagnostic.severity[diagnostics_level],
-			},
-		} or false,
-		-- set update_in_insert to false because it was enabled by lspsaga
 		update_in_insert = false,
 	})
 

--- a/lua/modules/configs/completion/tiny-inline-diagnostic.lua
+++ b/lua/modules/configs/completion/tiny-inline-diagnostic.lua
@@ -1,15 +1,47 @@
 return function()
 	require("modules.utils").load_plugin("tiny-inline-diagnostic", {
-		preset = "modern",
+		preset = "simple",
 		options = {
 			show_source = {
 				enabled = true,
 				if_many = true,
 			},
+			add_messages = true,
+			set_arrow_to_diag_color = false,
 			use_icons_from_diagnostic = true,
+			show_all_diags_on_cursorline = false,
 			break_line = {
 				enabled = true,
+				after = 80,
 			},
+			-- Filter severities up to the diagnostics level setting
+			severity = vim.tbl_filter(function(level)
+				return level <= vim.diagnostic.severity[require("core.settings").diagnostics_level]
+			end, {
+				vim.diagnostic.severity.ERROR,
+				vim.diagnostic.severity.WARN,
+				vim.diagnostic.severity.INFO,
+				vim.diagnostic.severity.HINT,
+			}),
+		},
+		disabled_ft = {
+			"alpha",
+			"checkhealth",
+			"dap-repl",
+			"diff",
+			"help",
+			"log",
+			"notify",
+			"NvimTree",
+			"Outline",
+			"qf",
+			"TelescopePrompt",
+			"toggleterm",
+			"undotree",
+			"vimwiki",
 		},
 	})
+
+	-- After setup, turn inline diagnostics on or off based on the `diagnostics_virtual_lines` setting
+	require("tiny-inline-diagnostic")[require("core.settings").diagnostics_virtual_lines and "enable" or "disable"]()
 end

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -26,6 +26,10 @@ completion["DNLHC/glance.nvim"] = {
 	event = "LspAttach",
 	config = require("completion.glance"),
 }
+completion["rachartier/tiny-inline-diagnostic.nvim"] = {
+	lazy = false,
+	config = require("completion.tiny-inline-diagnostic"),
+}
 completion["joechrisellis/lsp-format-modifications.nvim"] = {
 	lazy = true,
 	event = "LspAttach",
@@ -38,12 +42,6 @@ completion["nvimtools/none-ls.nvim"] = {
 		"nvim-lua/plenary.nvim",
 		"jay-babu/mason-null-ls.nvim",
 	},
-}
-completion["rachartier/tiny-inline-diagnostic.nvim"] = {
-	lazy = true,
-	event = "VeryLazy",
-	priority = 1000, -- needs to be loaded in first
-	config = require("completion.tiny-inline-diagnostic"),
 }
 completion["hrsh7th/nvim-cmp"] = {
 	lazy = true,


### PR DESCRIPTION
This change is mostly abt cleaning up how we handle inline diagnostics everywhere in the repo! The main visible difference i think ppl will notice is that i switched tiny-inline-diagnostic's preset from "modern" to "simple" cuz it seems to fit better w what we had before (but always open to switching it back lol). Aside from that, i went thru and renamed all the mentions of "virtual text" to "virtual lines" to be more accurate. Also i changed the plugin to load right at startup cuz i just took a look at its code and it acc changes some of nvim's default diagnostic settings and pretends those are the defaults, so it really needs to start early so nothing else overwrites its changes ~~(lsp shenanigans lol)~~. That said, it's still pretty lazy under the hood, so it shouldn't slow down startup noticeably since diagnostics won't acc run until a client is attached anyways.