### PR TITLE
fix: LSP start logic

### DIFF
--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -18,4 +18,6 @@ return function()
 	end
 
 	pcall(require, "user.configs.lsp")
+
+	pcall(vim.cmd.LspStart) -- Start LSPs
 end

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -19,5 +19,11 @@ return function()
 
 	pcall(require, "user.configs.lsp")
 
-	pcall(vim.cmd.LspStart) -- Start LSPs
+	-- Start LSPs
+	pcall(function()
+		local matching_configs = nvim_lsp.util.get_config_by_ft(vim.bo.filetype)
+		for _, config in ipairs(matching_configs) do
+			config.launch()
+		end
+	end)
 end

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -89,6 +89,7 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 				{ title = "nvim-lspconfig" }
 			)
 		end
+		return
 	end
 
 	for _, lsp in ipairs(lsp_deps) do

--- a/lua/modules/configs/editor/persisted.lua
+++ b/lua/modules/configs/editor/persisted.lua
@@ -1,16 +1,4 @@
 return function()
-	vim.api.nvim_create_autocmd("User", {
-		pattern = "PersistedLoadPost",
-		desc = "Fix LSP/Highlighting on auto session restore",
-		callback = function()
-			local bufname = vim.api.nvim_buf_get_name(0)
-			if bufname and bufname ~= "" then
-				vim.defer_fn(function()
-					vim.cmd("edit")
-				end, 1)
-			end
-		end,
-	})
 	require("modules.utils").load_plugin("persisted", {
 		save_dir = vim.fn.expand(vim.fn.stdpath("data") .. "/sessions/"),
 		autostart = true,

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -3,7 +3,7 @@ local use_copilot = require("core.settings").use_copilot
 
 completion["neovim/nvim-lspconfig"] = {
 	lazy = true,
-	event = { "BufReadPre", "BufNewFile" },
+	event = { "CursorHold", "CursorHoldI" },
 	config = require("completion.lsp"),
 	dependencies = {
 		{ "mason-org/mason.nvim" },


### PR DESCRIPTION
This PR should acc fix #1472 and #1479 cuz iirc the root cause was that lspconfig changed how `LspStart` works. Now it only starts one _specific_ server (passed via the first argument), instead of starting all matching servers automatically. So we gotta manually start all the servers that match the current filetype instead.