### PR TITLE
fix: only use realpath for vim_path

### DIFF
--- a/lua/core/global.lua
+++ b/lua/core/global.lua
@@ -8,8 +8,8 @@ function global:load_variables()
 	self.is_windows = os_name == "Windows_NT"
 	self.is_wsl = vim.fn.has("wsl") == 1
 	self.vim_path = realpath(vim.fn.stdpath("config"))
-	self.cache_dir = realpath(vim.fn.stdpath("cache"))
-	self.data_dir = string.format("%s/site/", realpath(vim.fn.stdpath("data")))
+	self.cache_dir = vim.fn.stdpath("cache")
+	self.data_dir = string.format("%s/site/", vim.fn.stdpath("data"))
 	self.modules_dir = self.vim_path .. "/modules"
 	self.home = self.is_windows and vim.env.USERPROFILE or vim.env.HOME
 end


### PR DESCRIPTION
This pr will fix #1521. In fact, only `vim_path` is needed to be a realpath.