### PR TITLE
fix(lspconfig): remove deprecated legacy framework of lspconfig

### DIFF
--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -7,7 +7,6 @@ M.setup = function()
 	local mason_registry = require("mason-registry")
 	local mason_lspconfig = require("mason-lspconfig")
 
-	require("lspconfig.ui.windows").default_options.border = "rounded"
 	require("modules.utils").load_plugin("mason-lspconfig", {
 		ensure_installed = lsp_deps,
 		-- Skip auto enable because we are loading language servers lazily


### PR DESCRIPTION
`require('lspconfig')` (lagacy flamework of `lspconfig`) is now deprecated, so neovim show warning.
I fixed to compliant with new method using vim.lsp.

- remove `require("lspconfig.ui.windows").default_options.border = "rounded"` in [configs/completion/mason-lspconfig.lua](lua/modules/configs/completion/mason-lspconfig.lua).
`:LuaInfo` is alias for `:checkhealth vim.lsp` so this is not floating window.
- Modified with reference to [nvim-lspconfig/lsp/clangd.lua](https://github.com/neovim/nvim-lspconfig/blob/master/lsp/clangd.lua)
  - Change command name from "ClangdSwitchSourceHeader" to "LspClangdSwitchSourceHeader" to compliant upstream.