### PR TITLE
fix(project): re-enable LSP detection

### DIFF
--- a/lua/modules/configs/tool/project.lua
+++ b/lua/modules/configs/tool/project.lua
@@ -1,7 +1,7 @@
 return function()
 	require("modules.utils").load_plugin("project", {
 		manual_mode = false,
-		detection_methods = { "pattern" },
+		use_lsp = true,
 		patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
 		ignore_lsp = { "null-ls", "copilot" },
 		exclude_dirs = {},


### PR DESCRIPTION
## Description

Hello there! Author of [`DrKJeff16/project.nvim`](https://github.com/DrKJeff16/project.nvim) here.

I've (hopefully :crossed_fingers:) resolved the issue with LSP detection methods. I've dropped the `detection_methods` option in favour of `use_lsp`. The traditional pattern matching is needed as a fallback [in case there's an inconsistency between root directory detection via LSP](https://github.com/DrKJeff16/project.nvim/issues/12).

Any feedback/suggestions please let me know!

Credits to @Cloud0310 for keeping up with changes!
