### PR TITLE
fix(edgy): add nil check for toggleterm terminal

### DIFF
--- a/lua/modules/configs/ui/edgy.lua
+++ b/lua/modules/configs/ui/edgy.lua
@@ -59,7 +59,7 @@ return function()
 				filter = function(_, win)
 					local cfg = vim.api.nvim_win_get_config(win)
 					local term = require("toggleterm.terminal").get(1)
-					return cfg.relative == "" and term.direction == "horizontal"
+					return cfg.relative == "" and term and term.direction == "horizontal"
 				end,
 			},
 			{


### PR DESCRIPTION
## Description

This PR fixes a nil reference error in `lua/modules/configs/ui/edgy.lua:62` that occurs when the toggleterm terminal has not been created yet.

Fixes #1545

## Changes

- Added nil check before accessing `term.direction` in the toggleterm filter function

## Root Cause

The `require("toggleterm.terminal").get(1)` call returns `nil` when terminal 1 doesn't exist yet. The code was trying to access `term.direction` without checking if `term` is nil first, causing the error:

```
edgy.nvim (x4672)
...edgy.lua:62: attempt to index local 'term' (a nil value)
```

## Solution

Changed line 62 from:
```lua
return cfg.relative == "" and term.direction == "horizontal"
```

To:
```lua
return cfg.relative == "" and term and term.direction == "horizontal"
```

This ensures that `term` is not nil before attempting to access its `direction` property.

## Testing

- Tested locally and confirmed the error no longer occurs
- The toggleterm window filtering still works correctly when terminals are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)