### PR TITLE
fix(treesitter): add autocmd for highlight and fix load plugin

### DIFF
--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -57,6 +57,14 @@ vim.api.nvim_create_autocmd("LspAttach", {
 	end,
 })
 
+-- Start treesitter for installed parsers
+vim.api.nvim_create_autocmd("FileType", {
+	pattern = require("core.settings").treesitter_deps,
+	callback = function(args)
+		vim.treesitter.start(args.buf)
+	end,
+})
+
 -- Autojump to last edit
 vim.api.nvim_create_autocmd("BufReadPost", {
 	callback = function()

--- a/lua/modules/configs/editor/treesitter.lua
+++ b/lua/modules/configs/editor/treesitter.lua
@@ -1,7 +1,7 @@
 return vim.schedule_wrap(function()
 	vim.api.nvim_set_option_value("indentexpr", "v:lua.require'nvim-treesitter'.indentexpr()", {})
 
-	require("modules.utils").load_plugin("nvim-treesitter")
+	require("modules.utils").load_plugin("nvim-treesitter", {})
 
 	require("nvim-treesitter").install(require("core.settings").treesitter_deps)
 end)


### PR DESCRIPTION
It seems that nvim-treesitter's upstream changes were followed in #1544, but this caused highlighting to no longer work.
(I checked python following pictures.)

| w/o highlight | w/ highlight |
|:-:|:-:|
|<img width="745" height="365" alt="2025-12-09_19-15_1" src="https://github.com/user-attachments/assets/ed5af756-e215-4079-a16e-3dac88a75739" />|<img width="738" height="386" alt="2025-12-09_19-15" src="https://github.com/user-attachments/assets/308bee7a-835f-46ae-9fc6-476920402e74" />|

Enable highlighting with neovim's standard function referring to [link](https://github.com/nvim-treesitter/nvim-treesitter/blob/b6271b678e035a5cbf62d637364f3eeca0890171/README.md?plain=1#L87-L96).
Legacy syntax support is expected to be configured on the plugin side and is not configured here ([docs](https://neovim.io/doc/user/treesitter.html#vim.treesitter.start())).
Also, if there is no `{}` in the load_plugins argument, an error will occur when overriding, so fixed this as well.