### PR TITLE
Fix deprecated tree-sitter package and update codecompanion v18

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -15,7 +15,7 @@
   "cmp-under-comparator": { "branch": "master", "commit": "6857f10272c3cfe930cece2afa2406e1385bfef8" },
   "cmp_luasnip": { "branch": "master", "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
   "codecompanion-history.nvim": { "branch": "main", "commit": "8c6ca9f998aeef89f3543343070f8562bf911fb4" },
-  "codecompanion.nvim": { "branch": "main", "commit": "e7762c68daf24c3e356401f5223eeb5217047754" },
+  "codecompanion.nvim": { "branch": "main", "commit": "e0780fa9fda504ffb89307cabcb6cbe1ce8eb60c" },
   "copilot-cmp": { "branch": "master", "commit": "15fc12af3d0109fa76b60b5cffa1373697e261d1" },
   "copilot.lua": { "branch": "master", "commit": "e78d1ffebdf6ccb6fd8be4e6898030c1cf5f9b64" },
   "crates.nvim": { "branch": "main", "commit": "ac9fa498a9edb96dc3056724ff69d5f40b898453" },

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -160,7 +160,6 @@ settings["treesitter_deps"] = {
 	"html",
 	"javascript",
 	"json",
-	"jsonc",
 	"latex",
 	"lua",
 	"make",

--- a/lua/modules/configs/tool/codecompanion.lua
+++ b/lua/modules/configs/tool/codecompanion.lua
@@ -24,13 +24,15 @@ return function()
 						modes = { n = "<CR>" },
 						description = "Submit",
 						callback = function(chat)
-							chat:apply_model(current_model)
 							chat:submit()
 						end,
 					},
 				},
 			},
 			inline = {
+				adapter = "openrouter",
+			},
+			cmd = {
 				adapter = "openrouter",
 			},
 		},
@@ -55,19 +57,61 @@ return function()
 		display = {
 			diff = {
 				enabled = true,
-				close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
-				layout = "vertical", -- vertical|horizontal split for default provider
-				opts = { "internal", "filler", "closeoff", "algorithm:patience", "followwrap", "linematch:120" },
-				provider = "default", -- default|mini_diff
+				provider = "inline", -- mini_diff|split|inline
+				provider_opts = {
+					inline = {
+						layout = "float", -- float|buffer
+					},
+				},
+				split = {
+					close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
+					layout = "vertical", -- vertical|horizontal split
+					opts = {
+						"internal",
+						"filler",
+						"closeoff",
+						"algorithm:histogram", -- https://adamj.eu/tech/2024/01/18/git-improve-diff-histogram/
+						"indent-heuristic", -- https://blog.k-nut.eu/better-git-diffs
+						"followwrap",
+						"linematch:120",
+					},
+				},
 			},
 			chat = {
 				window = {
+					auto_scroll = true,
+					border = "single",
+					full_height = true, -- when set to false, vsplit will be used to open the chat buffer vs. botright/topleft vsplit
 					layout = "vertical", -- float|vertical|horizontal|buffer
 					position = "right", -- left|right|top|bottom (nil will default depending on vim.opt.plitright|vim.opt.splitbelow)
-					border = "single",
-					width = 0.25,
 					relative = "editor",
-					full_height = true, -- when set to false, vsplit will be used to open the chat buffer vs. botright/topleft vsplit
+					show_header_separator = true,
+					width = 0.25,
+				},
+			},
+		},
+		rules = {
+			default = {
+				description = "Collection of common files for all projects",
+				files = {
+					".clinerules",
+					".cursorrules",
+					".goosehints",
+					".rules",
+					".windsurfrules",
+					".github/copilot-instructions.md",
+					"AGENT.md",
+					"AGENTS.md",
+					{ path = "CLAUDE.md", parser = "claude" },
+					{ path = "CLAUDE.local.md", parser = "claude" },
+					{ path = "~/.claude/CLAUDE.md", parser = "claude" },
+				},
+				is_preset = true,
+			},
+			opts = {
+				chat = {
+					autoload = "default", -- The rule groups to load
+					enabled = true,
 				},
 			},
 		},

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -75,7 +75,6 @@ tool["gelguy/wilder.nvim"] = {
 if settings.use_chat then
 	tool["olimorris/codecompanion.nvim"] = {
 		lazy = true,
-		tag = "v17.33.0",
 		event = "VeryLazy",
 		config = require("tool.codecompanion"),
 		dependencies = {


### PR DESCRIPTION
Now, `jsonc` that is tree-sitter package is not available by https://github.com/nvim-treesitter/nvim-treesitter/pull/8316
In addition, since [codecompanion](https://github.com/olimorris/codecompanion.nvim) and its extensions continue to be developed on top of v18, we’ll unpin them so they can track the latest version.