### PR TITLE
fix(cmp): reduce blink-ripgrep freeze in complex directories

### DIFF
--- a/lua/modules/configs/completion/blink.lua
+++ b/lua/modules/configs/completion/blink.lua
@@ -83,10 +83,10 @@ local opts = {
 				opts = {
 					prefix_min_len = 3,
 					backend = {
-						use = "ripgrep",
+						use = "gitgrep-or-ripgrep",
 						context_size = 0,
 						ripgrep = {
-							max_filesize = "1M",
+							max_filesize = "200K",
 							additional_rg_options = { "--max-count=5" },
 						},
 					},

--- a/lua/modules/configs/completion/blink.lua
+++ b/lua/modules/configs/completion/blink.lua
@@ -81,12 +81,13 @@ local opts = {
 				module = "blink-ripgrep",
 				name = "Ripgrep",
 				opts = {
-					prefix_min_len = 2,
+					prefix_min_len = 3,
 					backend = {
 						use = "ripgrep",
+						context_size = 0,
 						ripgrep = {
-							context_size = 5,
 							max_filesize = "1M",
+							additional_rg_options = { "--max-count=5" },
 						},
 					},
 				},

--- a/lua/modules/configs/completion/blink.lua
+++ b/lua/modules/configs/completion/blink.lua
@@ -84,9 +84,9 @@ local opts = {
 					prefix_min_len = 3,
 					backend = {
 						use = "gitgrep-or-ripgrep",
-						context_size = 0,
 						ripgrep = {
 							max_filesize = "200K",
+							context_size = 3,
 							additional_rg_options = { "--max-count=5" },
 						},
 					},


### PR DESCRIPTION
## Summary

- Increase `prefix_min_len` from 2 to 3, reducing how often ripgrep is triggered while typing
- Move `context_size` to the correct `backend` scope (was silently ignored under `backend.ripgrep`) and set it to 0 to eliminate context-line parsing overhead
- Add `--max-count=5` to `additional_rg_options` so ripgrep exits each file after 5 matches instead of scanning the entire tree

## Test plan

- [ ] Open a file inside a large/complex directory
- [ ] Enter insert mode and type 3+ characters
- [ ] Verify completion suggestions appear without freezing
- [ ] Verify ripgrep suggestions still show up in the completion menu

Fixes #1574