### PR TITLE
fix(rainbow_delims): add nil check for treesitter parser

### DIFF
--- a/lua/modules/configs/editor/rainbow_delims.lua
+++ b/lua/modules/configs/editor/rainbow_delims.lua
@@ -9,8 +9,12 @@ return function()
 			end
 
 			-- Disable on parser error
+			local parser = vim.treesitter.get_parser()
+			if not parser then
+				return nil
+			end
 			local errors = 200
-			vim.treesitter.get_parser():for_each_tree(function(lt)
+			parser:for_each_tree(function(lt)
 				if lt:root():has_error() and errors >= 0 then
 					errors = errors - 1
 				end


### PR DESCRIPTION
## Description

This PR fixes a runtime error that occurs in Neovim 0.12 when opening files without a treesitter parser.

### Problem

In Neovim 0.12, `vim.treesitter.get_parser()` returns `nil` when no parser is available, instead of throwing an error. This caused the following error when opening files:

```
Error in BufReadPost Autocommands for "*":
Lua callback: ...onfig/nvim/lua/modules/configs/editor/rainbow_delims.lua:13: attempt to index a nil value
```

### Solution

Added a nil check before calling `:for_each_tree()` on the parser. When no parser is available, the function now gracefully returns `nil` (disabling rainbow delimiters) instead of causing a runtime error.

### Changes

- `lua/modules/configs/editor/rainbow_delims.lua`: Added nil check for `vim.treesitter.get_parser()` return value

### Testing

- Tested on Neovim 0.12.2
- Verified the error no longer occurs when opening files without treesitter parsers
- Confirmed rainbow delimiters still work correctly for files with parsers

Fixes #1562

---

## 描述

此 PR 修复了在 Neovim 0.12 中打开没有 treesitter 解析器的文件时出现的运行时错误。

### 问题

在 Neovim 0.12 中，当没有可用的解析器时，`vim.treesitter.get_parser()` 会返回 `nil`，而不是抛出错误。这导致在打开文件时出现以下错误：

```
Error in BufReadPost Autocommands for "*":
Lua callback: ...onfig/nvim/lua/modules/configs/editor/rainbow_delims.lua:13: attempt to index a nil value
```

### 解决方案

在调用 `:for_each_tree()` 之前添加了 nil 检查。当没有可用的解析器时，函数现在会优雅地返回 `nil`（禁用 rainbow delimiters），而不是导致运行时错误。

### 修改内容

- `lua/modules/configs/editor/rainbow_delims.lua`：为 `vim.treesitter.get_parser()` 返回值添加 nil 检查

### 测试

- 在 Neovim 0.12.2 上测试
- 验证打开没有 treesitter 解析器的文件时不再出现错误
- 确认有解析器的文件仍然正常显示 rainbow delimiters

修复 #1562