### PR TITLE
fix(formatter): fix cland-format don't use default .clang_format config

### DIFF
--- a/lua/modules/configs/completion/formatters/clang_format.lua
+++ b/lua/modules/configs/completion/formatters/clang_format.lua
@@ -3,5 +3,6 @@ local project_root = vim.fs.root(vim.fn.getcwd(), { ".git" }) or vim.fn.getcwd()
 -- check if ".clang-format" config exists, if it does, use the config instead of default
 if not vim.uv.fs_stat(vim.fs.joinpath(project_root, ".clang-format")) then
 	return { "-style={ BasedOnStyle: LLVM, IndentWidth: 4 }" }
+else
+	return { "-style=file" }
 end
-return {}


### PR DESCRIPTION
The previous clang format config is ignored, and is pointing to no config. This new change fixed this problem by explicitly set flags here.