### PR TITLE
fix(ui): guard against nil colors_name in lualine/bufferline

### DIFF
--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -42,7 +42,7 @@ return function()
 		highlights = {},
 	}
 
-	if vim.g.colors_name:find("catppuccin") then
+	if (vim.g.colors_name or ""):find("catppuccin") then
 		local cp = require("modules.utils").get_palette() -- Get the palette.
 
 		local catppuccin_hl_overwrite = {

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -41,7 +41,7 @@ vim.api.nvim_create_autocmd("LspProgress", {
 })
 
 return function()
-	local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+	local has_catppuccin = (vim.g.colors_name or ""):find("catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -57,7 +57,7 @@ return function()
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
 			pattern = "*",
 			callback = function()
-				has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+				has_catppuccin = (vim.g.colors_name or ""):find("catppuccin") ~= nil
 				require("lualine").setup({ options = { theme = custom_theme() } })
 			end,
 		})


### PR DESCRIPTION
## What

`lualine.lua` and `bufferline.lua` call `vim.g.colors_name:find("catppuccin")` directly. `vim.g.colors_name` is `nil` until a colorscheme has been applied (e.g. `nvim --clean`, or before `:colorscheme` runs), so `nil:find()` raises `attempt to index a nil value` if either module loads at that point.

This coalesces to an empty string in all three spots:

- `lua/modules/configs/ui/lualine.lua:44`
- `lua/modules/configs/ui/lualine.lua:60` (inside the `ColorScheme` autocmd callback)
- `lua/modules/configs/ui/bufferline.lua:45`

```lua
(vim.g.colors_name or ""):find("catppuccin")
```

## Why

This matches the nil-safe pattern already used in `lua/modules/utils/init.lua` (`get_palette` and `set_global_hl`), so it just brings these two UI configs in line with the rest of the codebase.

Behaviour is unchanged when a colorscheme is set:
- `("catppuccin-mocha" or ""):find("catppuccin")` → match (truthy), as before
- `(nil or ""):find("catppuccin")` → no match, **no error** (previously errored)

## Verification

- `stylua lua/` — clean.
- `grep -rn 'vim.g.colors_name:find' lua/` → no bare occurrences remain.
- Verified empirically that `vim.g.colors_name` is `nil` under `nvim --clean`.