### PR TITLE
feat: discovery-first tool resolution (make Mason optional)

### DIFF
--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -225,8 +225,9 @@ settings["lsp_deps"] = {
 	"clangd",
 	-- Servers without a Mason package resolve straight from $PATH via their
 	-- manual spec under `completion/servers/` — list them here like any other
-	-- server (e.g. dartls: the `dart` executable ships the language server).
-	-- "dartls",
+	-- server. dartls needs no entry: it is auto-added whenever the `dart`
+	-- executable (which ships the language server) is on $PATH; listing it
+	-- here explicitly instead surfaces the missing-tool warning when absent.
 	"gopls",
 	"html",
 	"jsonls",

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -223,6 +223,10 @@ settings["lsp_inlayhints"] = false
 settings["lsp_deps"] = {
 	"bashls",
 	"clangd",
+	-- Servers without a Mason package resolve straight from $PATH via their
+	-- manual spec under `completion/servers/` — list them here like any other
+	-- server (e.g. dartls: the `dart` executable ships the language server).
+	-- "dartls",
 	"gopls",
 	"html",
 	"jsonls",

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -1,21 +1,11 @@
 return function()
 	require("completion.neoconf").setup()
+	-- All servers — including ones without a Mason package (dartls, say) — are
+	-- resolved discovery-first from the single `lsp_deps` list inside
+	-- mason-lspconfig.setup: a server whose manual spec names its binary is
+	-- probed on $PATH and configured when present, so no per-server
+	-- `vim.fn.executable(...)` special case is needed here.
 	require("completion.mason-lspconfig").setup()
-
-	local opts = {
-		capabilities = require("modules.utils").get_lsp_capabilities(),
-	}
-	-- Configure LSPs that are not supported by `mason.nvim` but are available in `nvim-lspconfig`.
-	-- First call |vim.lsp.config()|, then |vim.lsp.enable()| (or use `register_server`, see below)
-	-- to ensure the language server is properly configured and starts automatically.
-	if vim.fn.executable("dart") == 1 then
-		local ok, _opts = pcall(require, "user.configs.lsp-servers.dartls")
-		if not ok then
-			_opts = require("completion.servers.dartls")
-		end
-		local final_opts = vim.tbl_deep_extend("keep", _opts, opts)
-		require("modules.utils").register_server("dartls", final_opts)
-	end
 
 	pcall(require, "user.configs.lsp")
 

--- a/lua/modules/configs/completion/lsp.lua
+++ b/lua/modules/configs/completion/lsp.lua
@@ -1,10 +1,12 @@
 return function()
 	require("completion.neoconf").setup()
-	-- All servers — including ones without a Mason package (dartls, say) — are
-	-- resolved discovery-first from the single `lsp_deps` list inside
+	-- All servers — including ones without a Mason package — are resolved
+	-- discovery-first from the single `lsp_deps` list inside
 	-- mason-lspconfig.setup: a server whose manual spec names its binary is
 	-- probed on $PATH and configured when present, so no per-server
-	-- `vim.fn.executable(...)` special case is needed here.
+	-- `vim.fn.executable(...)` special case is needed here (dartls keeps its
+	-- historical auto-enable — it is injected into the list there whenever
+	-- `dart` is on $PATH).
 	require("completion.mason-lspconfig").setup()
 
 	pcall(require, "user.configs.lsp")

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -98,12 +98,17 @@ M.setup = function()
 		-- just to probe existence would run its module-level code for the side
 		-- effects. Neovim keeps package.path in sync with 'runtimepath' (see
 		-- :h lua-package-path), so searchpath sees the same modules require would.
-		if package.searchpath(module, package.path) then
+		-- The found path names the offending file directly, so the guidance is
+		-- right for a user override as well as a repo preset.
+		local path = package.searchpath(module, package.path)
+		if path then
 			vim.notify(
-				[[
-`rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,
-please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` directory and configure
-`rust_analyzer` using the appropriate init options provided by `rustaceanvim` instead.]],
+				string.format(
+					"`rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,\n"
+						.. "please REMOVE the conflicting spec at `%s`\n"
+						.. "and configure `rust_analyzer` using the appropriate init options provided by `rustaceanvim` instead.",
+					path
+				),
 				vim.log.levels.WARN,
 				{ title = "nvim-lspconfig" }
 			)

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -154,8 +154,21 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 			return cached
 		end
 		local info = { has_module = false, binary = nil }
-		for _, module in ipairs({ "user.configs.lsp-servers." .. name, "completion.servers." .. name }) do
-			local ok, spec = pcall(require, module)
+		local user_ok, user_spec = pcall(require, "user.configs.lsp-servers." .. name)
+		if user_ok then
+			info.has_module = true
+			if type(user_spec) == "table" and type(user_spec.cmd) == "table" then
+				info.binary = user_spec.cmd[1]
+			end
+		end
+		-- Load the repo preset only when it can inform this probe: when there is no
+		-- user override (existence and the binary must come from the preset), or
+		-- when a table-form override carries no cmd (the preset is the merge base
+		-- that may). A function-form override replaces the preset wholesale
+		-- (mason_lsp_handler never reads it), so requiring it here would run the
+		-- preset's module-level code for a spec that cannot be used.
+		if not user_ok or (type(user_spec) == "table" and info.binary == nil) then
+			local ok, spec = pcall(require, "completion.servers." .. name)
 			if ok then
 				info.has_module = true
 				if info.binary == nil and type(spec) == "table" and type(spec.cmd) == "table" then

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -2,14 +2,12 @@ local M = {}
 
 M.setup = function()
 	local lsp_deps = require("core.settings").lsp_deps
-	local mason_registry = require("mason-registry")
-	local mason_lspconfig = require("mason-lspconfig")
-
-	require("modules.utils").load_plugin("mason-lspconfig", {
-		ensure_installed = lsp_deps,
-		-- Skip auto enable because we are loading language servers lazily
-		automatic_enable = false,
-	})
+	-- Mason is an optional installer backend: guard its requires so a Mason-less
+	-- setup still resolves servers from $PATH instead of hard-erroring here.
+	local has_registry, mason_registry = pcall(require, "mason-registry")
+	local has_mlsp, mason_lspconfig = pcall(require, "mason-lspconfig")
+	local mason_ok = has_registry and has_mlsp
+	local tools = require("modules.utils.tools")
 
 	vim.diagnostic.config({
 		signs = true,
@@ -81,37 +79,91 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		end
 	end
 
-	---A simplified mimic of <mason-lspconfig 1.x>'s `setup_handlers` callback.
-	---Invoked for each Mason package (name or `Package` object) to configure its language server.
-	---@param pkg string|{name: string} Either the package name (string) or a Package object
-	local function setup_lsp_for_package(pkg)
-		-- First try to grab the builtin mappings
-		local mappings = mason_lspconfig.get_mappings().package_to_lspconfig
-		-- If empty or nil, build it by hand
-		if not mappings or vim.tbl_isempty(mappings) then
-			mappings = {}
-			for _, spec in ipairs(mason_registry.get_all_package_specs()) do
-				local lspconfig = vim.tbl_get(spec, "neovim", "lspconfig")
-				if lspconfig then
-					mappings[spec.name] = lspconfig
-				end
+	if mason_ok then
+		-- Load mason-lspconfig for the lspconfig integration only. Installs are
+		-- driven by the shared resolver (discovery-first) so they degrade gracefully
+		-- where Mason can't help (BSD/NixOS/...), instead of being gated on the
+		-- installed set.
+		require("modules.utils").load_plugin("mason-lspconfig", {
+			ensure_installed = {},
+			-- Skip auto enable because we are loading language servers lazily
+			automatic_enable = false,
+		})
+	end
+
+	-- lspconfig server name -> Mason package name. Resolved lazily on first use so
+	-- it is read *after* the resolver's registry refresh, when `get_mappings()`
+	-- returns a fully populated map (fresh-bootstrap fix). nil when Mason absent.
+	local lspconfig_to_package = nil
+	local function package_of(name)
+		if not mason_ok then
+			return nil
+		end
+		if lspconfig_to_package == nil then
+			local mappings = mason_lspconfig.get_mappings()
+			lspconfig_to_package = (mappings and mappings.lspconfig_to_package) or {}
+		end
+		return lspconfig_to_package[name]
+	end
+
+	---Resolve a server's launch binary for the $PATH probe. Prefer an explicit
+	---`cmd` from the manual spec (user override, then repo default under
+	---`completion/servers/`), then fall back to nvim-lspconfig's default `cmd`.
+	---Returns nil when the spec only exposes a function `cmd` (or no `cmd`): the
+	---binary can't be probed statically, so resolution falls through to the
+	---`has_local_config` path, which configures the server and lets it resolve its
+	---own command, rather than wrongly flagging it missing.
+	---@param name string
+	---@return string|nil
+	local function server_binary(name)
+		for _, module in ipairs({ "user.configs.lsp-servers." .. name, "completion.servers." .. name }) do
+			local ok, spec = pcall(require, module)
+			if ok and type(spec) == "table" and type(spec.cmd) == "table" then
+				return spec.cmd[1]
 			end
 		end
-
-		-- Figure out the package name and lookup
-		local name = type(pkg) == "string" and pkg or pkg.name
-		local srv = mappings[name]
-		if not srv then
-			return
+		local ok, config = pcall(function()
+			return vim.lsp.config[name]
+		end)
+		if ok and type(config) == "table" and type(config.cmd) == "table" then
+			return config.cmd[1]
 		end
-
-		-- Invoke the handler
-		mason_lsp_handler(srv)
+		return nil
 	end
 
-	for _, pkg in ipairs(mason_registry.get_installed_package_names()) do
-		setup_lsp_for_package(pkg)
+	---Should a manual spec be treated as a resolution fallback (configure now even
+	---though the $PATH probe found nothing)? Only when the launch binary can't be
+	---probed statically — i.e. `server_binary` returned nil (a function/absent `cmd`
+	---that resolves itself at launch). When the binary *is* known (e.g. shuck's
+	---`cmd = { "shuck" }`), the $PATH check already decides availability; configuring
+	---anyway would silently enable a server whose binary is missing instead of
+	---surfacing it in the aggregated warning.
+	---@param name string
+	---@return boolean
+	local function has_local_config(name)
+		if server_binary(name) ~= nil then
+			return false
+		end
+		for _, module in ipairs({ "user.configs.lsp-servers." .. name, "completion.servers." .. name }) do
+			if pcall(require, module) then
+				return true
+			end
+		end
+		return false
 	end
+
+	tools.resolve({
+		title = "LSP",
+		deps = lsp_deps,
+		registry = mason_ok and mason_registry or nil,
+		package_of = package_of,
+		binaries_of = function(name)
+			local binary = server_binary(name)
+			return binary and { binary } or {}
+		end,
+		has_local_config = has_local_config,
+		configure = mason_lsp_handler,
+	})
 end
 
 return M

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -84,7 +84,12 @@ M.setup = function()
 	-- `lsp_deps` (the resolver below only visits deps entries, so the old
 	-- inside-the-handler warning would never fire for the common case).
 	for _, module in ipairs({ "user.configs.lsp-servers.rust_analyzer", "completion.servers.rust_analyzer" }) do
-		if pcall(require, module) then
+		-- Presence check WITHOUT executing the module: a stray spec should be
+		-- reported even when it errors at load (especially then), and requiring it
+		-- just to probe existence would run its module-level code for the side
+		-- effects. Neovim keeps package.path in sync with 'runtimepath' (see
+		-- :h lua-package-path), so searchpath sees the same modules require would.
+		if package.searchpath(module, package.path) then
 			vim.notify(
 				[[
 `rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -19,6 +19,26 @@ M.setup = function()
 	local mason_ok = has_registry and has_mlsp
 	local tools = require("modules.utils.tools")
 
+	---Locate a module file on the search paths require() uses, WITHOUT executing
+	---it. package.searchpath alone is not enough: `user.*` modules live under a
+	---runtimepath `lua/` dir and are found by Neovim's runtimepath loader, not
+	---package.path — while `completion.servers.*` is the reverse (reachable only
+	---through the package.path entries core/pack.lua appends). Probe both.
+	---@param module string
+	---@return string|nil
+	local function module_path(module)
+		local path = package.searchpath(module, package.path)
+		if path then
+			return path
+		end
+		local base = "lua/" .. module:gsub("%.", "/")
+		local hits = vim.api.nvim_get_runtime_file(base .. ".lua", false)
+		if #hits == 0 then
+			hits = vim.api.nvim_get_runtime_file(base .. "/init.lua", false)
+		end
+		return hits[1]
+	end
+
 	vim.diagnostic.config({
 		signs = true,
 		underline = true,
@@ -96,11 +116,9 @@ M.setup = function()
 		-- Presence check WITHOUT executing the module: a stray spec should be
 		-- reported even when it errors at load (especially then), and requiring it
 		-- just to probe existence would run its module-level code for the side
-		-- effects. Neovim keeps package.path in sync with 'runtimepath' (see
-		-- :h lua-package-path), so searchpath sees the same modules require would.
-		-- The found path names the offending file directly, so the guidance is
-		-- right for a user override as well as a repo preset.
-		local path = package.searchpath(module, package.path)
+		-- effects. The found path names the offending file directly, so the
+		-- guidance is right for a user override as well as a repo preset.
+		local path = module_path(module)
 		if path then
 			vim.notify(
 				string.format(
@@ -159,12 +177,31 @@ M.setup = function()
 			return cached
 		end
 		local info = { has_module = false, binary = nil }
+		---A spec file that exists but throws at load is a broken config, not a
+		---missing one: count it as a module and surface the load error
+		---(server_info is cached, so once per server).
+		---@param module string
+		---@param err any @The pcall error for the failed require.
+		---@return boolean @Whether the module file exists on the search paths.
+		local function report_broken_spec(module, err)
+			if not module_path(module) then
+				return false
+			end
+			vim.notify(
+				string.format("Failed to load `%s`:\n%s", module, err),
+				vim.log.levels.ERROR,
+				{ title = "nvim-lspconfig" }
+			)
+			return true
+		end
 		local user_ok, user_spec = pcall(require, "user.configs.lsp-servers." .. name)
 		if user_ok then
 			info.has_module = true
 			if type(user_spec) == "table" and type(user_spec.cmd) == "table" then
 				info.binary = user_spec.cmd[1]
 			end
+		elseif report_broken_spec("user.configs.lsp-servers." .. name, user_spec) then
+			info.has_module = true
 		end
 		-- Load the repo preset only when it can inform this probe: when there is no
 		-- user override (existence and the binary must come from the preset), or
@@ -179,6 +216,8 @@ M.setup = function()
 				if info.binary == nil and type(spec) == "table" and type(spec.cmd) == "table" then
 					info.binary = spec.cmd[1]
 				end
+			elseif report_broken_spec("completion.servers." .. name, spec) then
+				info.has_module = true
 			end
 		end
 		if info.binary == nil then

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -174,6 +174,38 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		return info.binary == nil and info.has_module
 	end
 
+	---Mirror the none-ls `PATH = "skip"` handling (see mason-null-ls.lua): a
+	---Mason-installed server counts as available (`is_installed()`) even when its
+	---binary is only resolvable inside Mason's bin dir, so the handler above would
+	---register a bare `cmd[1]` that lspconfig later fails to spawn. After the
+	---handler runs, rewrite the *registered* config's `cmd[1]` to the absolute
+	---path find_executable resolves (it probes Mason's bin dir after $PATH).
+	---Checked against the registered cmd — not the cached spec probe — so user
+	---overrides and lspconfig defaults are covered alike; function `cmd`s (which
+	---resolve themselves at launch) and already-spawnable names are left alone.
+	---@param name string
+	local function rewrite_cmd_off_path(name)
+		local ok, config = pcall(function()
+			return vim.lsp.config[name]
+		end)
+		if not ok or type(config) ~= "table" or type(config.cmd) ~= "table" then
+			return
+		end
+		local binary = config.cmd[1]
+		if type(binary) ~= "string" or binary == "" or vim.fn.executable(binary) == 1 then
+			return
+		end
+		local path = tools.find_executable(binary)
+		if not path then
+			return
+		end
+		local cmd = vim.deepcopy(config.cmd)
+		cmd[1] = path
+		-- Lists are replaced wholesale (not index-merged) by the deep-extend in
+		-- vim.lsp.config(), so the full rewritten cmd is passed back.
+		vim.lsp.config(name, { cmd = cmd })
+	end
+
 	tools.resolve({
 		title = "LSP",
 		deps = lsp_deps,
@@ -184,7 +216,10 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 			return binary and { binary } or {}
 		end,
 		has_local_config = has_local_config,
-		configure = mason_lsp_handler,
+		configure = function(name)
+			mason_lsp_handler(name)
+			rewrite_cmd_off_path(name)
+		end,
 	})
 end
 

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -22,20 +22,10 @@ M.setup = function()
 	---A handler to setup all servers defined under `completion/servers/*.lua`
 	---@param lsp_name string
 	local function mason_lsp_handler(lsp_name)
-		-- rust_analyzer is configured using mrcjkb/rustaceanvim
-		-- warn users if they have set it up manually
+		-- rust_analyzer is configured using mrcjkb/rustaceanvim; never configure it
+		-- here (the stray-config warning is issued unconditionally in setup below,
+		-- since this handler only runs for `lsp_deps` entries).
 		if lsp_name == "rust_analyzer" then
-			local config_exist = pcall(require, "completion.servers." .. lsp_name)
-			if config_exist then
-				vim.notify(
-					[[
-`rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,
-please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` directory and configure
-`rust_analyzer` using the appropriate init options provided by `rustaceanvim` instead.]],
-					vim.log.levels.WARN,
-					{ title = "nvim-lspconfig" }
-				)
-			end
 			return
 		end
 
@@ -79,6 +69,24 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		end
 	end
 
+	-- rust_analyzer is configured independently via mrcjkb/rustaceanvim; a stray
+	-- manual spec is a misconfiguration regardless of whether rust_analyzer is in
+	-- `lsp_deps` (the resolver below only visits deps entries, so the old
+	-- inside-the-handler warning would never fire for the common case).
+	for _, module in ipairs({ "user.configs.lsp-servers.rust_analyzer", "completion.servers.rust_analyzer" }) do
+		if pcall(require, module) then
+			vim.notify(
+				[[
+`rust_analyzer` is configured independently via `mrcjkb/rustaceanvim`. To get rid of this warning,
+please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` directory and configure
+`rust_analyzer` using the appropriate init options provided by `rustaceanvim` instead.]],
+				vim.log.levels.WARN,
+				{ title = "nvim-lspconfig" }
+			)
+			break
+		end
+	end
+
 	if mason_ok then
 		-- Load mason-lspconfig for the lspconfig integration only. Installs are
 		-- driven by the shared resolver (discovery-first) so they degrade gracefully
@@ -106,50 +114,54 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		return lspconfig_to_package[name]
 	end
 
-	---Resolve a server's launch binary for the $PATH probe. Prefer an explicit
-	---`cmd` from the manual spec (user override, then repo default under
-	---`completion/servers/`), then fall back to nvim-lspconfig's default `cmd`.
-	---Returns nil when the spec only exposes a function `cmd` (or no `cmd`): the
-	---binary can't be probed statically, so resolution falls through to the
-	---`has_local_config` path, which configures the server and lets it resolve its
-	---own command, rather than wrongly flagging it missing.
+	---Probe a server's manual spec once and cache the result, so the resolver's
+	---predicates (binaries_of / has_local_config) don't re-require the same modules
+	---for every call (mirrors mason-null-ls.lua's info() cache). `binary` prefers an
+	---explicit `cmd` from the manual spec (user override, then repo default under
+	---`completion/servers/`), then nvim-lspconfig's default `cmd`; it stays nil when
+	---only a function `cmd` (or none) exists — such a spec resolves its own command
+	---at launch, so it becomes the `has_local_config` fallback instead.
+	local server_info_cache = {}
 	---@param name string
-	---@return string|nil
-	local function server_binary(name)
+	---@return { has_module: boolean, binary: string|nil }
+	local function server_info(name)
+		local cached = server_info_cache[name]
+		if cached then
+			return cached
+		end
+		local info = { has_module = false, binary = nil }
 		for _, module in ipairs({ "user.configs.lsp-servers." .. name, "completion.servers." .. name }) do
 			local ok, spec = pcall(require, module)
-			if ok and type(spec) == "table" and type(spec.cmd) == "table" then
-				return spec.cmd[1]
+			if ok then
+				info.has_module = true
+				if info.binary == nil and type(spec) == "table" and type(spec.cmd) == "table" then
+					info.binary = spec.cmd[1]
+				end
 			end
 		end
-		local ok, config = pcall(function()
-			return vim.lsp.config[name]
-		end)
-		if ok and type(config) == "table" and type(config.cmd) == "table" then
-			return config.cmd[1]
+		if info.binary == nil then
+			local ok, config = pcall(function()
+				return vim.lsp.config[name]
+			end)
+			if ok and type(config) == "table" and type(config.cmd) == "table" then
+				info.binary = config.cmd[1]
+			end
 		end
-		return nil
+		server_info_cache[name] = info
+		return info
 	end
 
 	---Should a manual spec be treated as a resolution fallback (configure now even
 	---though the $PATH probe found nothing)? Only when the launch binary can't be
-	---probed statically — i.e. `server_binary` returned nil (a function/absent `cmd`
-	---that resolves itself at launch). When the binary *is* known (e.g. shuck's
-	---`cmd = { "shuck" }`), the $PATH check already decides availability; configuring
-	---anyway would silently enable a server whose binary is missing instead of
-	---surfacing it in the aggregated warning.
+	---probed statically — a function/absent `cmd` that resolves itself at launch.
+	---When the binary *is* known (e.g. shuck's `cmd = { "shuck" }`), the $PATH check
+	---already decides availability; configuring anyway would silently enable a
+	---server whose binary is missing instead of surfacing it in the warning.
 	---@param name string
 	---@return boolean
 	local function has_local_config(name)
-		if server_binary(name) ~= nil then
-			return false
-		end
-		for _, module in ipairs({ "user.configs.lsp-servers." .. name, "completion.servers." .. name }) do
-			if pcall(require, module) then
-				return true
-			end
-		end
-		return false
+		local info = server_info(name)
+		return info.binary == nil and info.has_module
 	end
 
 	tools.resolve({
@@ -158,7 +170,7 @@ please REMOVE your LSP configuration (rust_analyzer.lua) from the `servers` dire
 		registry = mason_ok and mason_registry or nil,
 		package_of = package_of,
 		binaries_of = function(name)
-			local binary = server_binary(name)
+			local binary = server_info(name).binary
 			return binary and { binary } or {}
 		end,
 		has_local_config = has_local_config,

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -2,6 +2,16 @@ local M = {}
 
 M.setup = function()
 	local lsp_deps = require("core.settings").lsp_deps
+	-- dartls ships inside the Dart SDK (no Mason package), so its availability is
+	-- keyed on the `dart` executable: auto-add it when `dart` is on $PATH — same
+	-- auto-enable behavior as the historical inline check in `lsp.lua`, but routed
+	-- through the shared resolver like every other server. Copy-on-inject keeps
+	-- the shared settings table unmutated; an explicit "dartls" entry in
+	-- `lsp_deps` still works (and forces the missing-tool warning when `dart`
+	-- is absent).
+	if vim.fn.executable("dart") == 1 and not vim.tbl_contains(lsp_deps, "dartls") then
+		lsp_deps = vim.list_extend({ "dartls" }, lsp_deps)
+	end
 	-- Mason is an optional installer backend: guard its requires so a Mason-less
 	-- setup still resolves servers from $PATH instead of hard-erroring here.
 	local has_registry, mason_registry = pcall(require, "mason-registry")

--- a/lua/modules/configs/completion/mason-lspconfig.lua
+++ b/lua/modules/configs/completion/mason-lspconfig.lua
@@ -40,7 +40,16 @@ M.setup = function()
 		end
 
 		local ok, custom_handler = pcall(require, "user.configs.lsp-servers." .. lsp_name)
-		local default_ok, default_handler = pcall(require, "completion.servers." .. lsp_name)
+		-- Load the repo preset only when it can actually be used: as the spec when
+		-- there is no user override, or as the merge base under a table-form
+		-- override. A function-form override replaces the preset wholesale, so
+		-- requiring it would only run the preset's module-level code (vim.fn.expand
+		-- & co.) for nothing — and could surface preset-load errors the override
+		-- deliberately avoids.
+		local default_ok, default_handler = false, nil
+		if not ok or type(custom_handler) == "table" then
+			default_ok, default_handler = pcall(require, "completion.servers." .. lsp_name)
+		end
 		-- Use preset if there is no user definition
 		if not ok then
 			ok, custom_handler = default_ok, default_handler

--- a/lua/modules/configs/completion/mason-null-ls.lua
+++ b/lua/modules/configs/completion/mason-null-ls.lua
@@ -1,11 +1,109 @@
 local M = {}
 
 M.setup = function()
-	require("modules.utils").load_plugin("mason-null-ls", {
-		ensure_installed = require("core.settings").null_ls_deps,
-		automatic_installation = false,
-		automatic_setup = true,
-		handlers = {},
+	local null_ls = require("null-ls")
+	local tools = require("modules.utils.tools")
+	local null_ls_deps = require("core.settings").null_ls_deps
+
+	-- mason-null-ls's `automatic_setup` registers only *installed* sources, so a
+	-- source available on $PATH but not Mason-installed would never activate.
+	-- Drive it discovery-first instead: register any available source, install
+	-- those Mason can provide, and surface the rest in one warning.
+	--
+	-- Mason is an optional backend: guard its requires so a Mason-less setup still
+	-- registers sources whose binary is on $PATH (it just can't install missing ones).
+	local has_registry, mason_registry = pcall(require, "mason-registry")
+	local has_map, source_map = pcall(require, "mason-null-ls.mappings.source")
+	local mason_ok = has_registry and has_map
+	if mason_ok then
+		require("modules.utils").load_plugin("mason-null-ls", {
+			ensure_installed = {},
+			automatic_installation = false,
+			automatic_setup = false,
+			handlers = {},
+		})
+	end
+
+	local methods = { "formatting", "diagnostics", "code_actions", "hover", "completion" }
+
+	---Resolve a none-ls source to its builtin(s) and the binary it invokes.
+	---Uses `pcall(require, ...)` to probe methods (as mason-null-ls does) so
+	---probing the wrong method never emits a "failed to load builtin" log.
+	---@param source string
+	---@return table[] builtins, string|nil binary
+	local function resolve_source(source)
+		local builtins, binary = {}, nil
+		for _, method in ipairs(methods) do
+			local ok, builtin = pcall(require, string.format("null-ls.builtins.%s.%s", method, source))
+			if ok and type(builtin) == "table" then
+				builtins[#builtins + 1] = builtin
+				if not binary then
+					local command = builtin._opts and builtin._opts.command
+					-- Only a string command is $PATH-probeable. A function command is
+					-- resolved dynamically by none-ls, and vim.fn.executable() errors on
+					-- a non-string; leave binary nil so the source is treated as needing
+					-- no external binary (registered directly below).
+					binary = type(command) == "string" and command or nil
+				end
+			end
+		end
+		return builtins, binary
+	end
+
+	---Register a source's builtin(s), unless it's already registered. The guard
+	---preserves sources configured explicitly in `null-ls.lua` (e.g. clang_format,
+	---prettier with custom filetypes/args), which run before this resolver.
+	---@param source string
+	---@param builtins table[]
+	local function register(source, builtins)
+		if null_ls.is_registered(source) then
+			return
+		end
+		for _, builtin in ipairs(builtins) do
+			null_ls.register(builtin)
+		end
+	end
+
+	-- Cache each source's resolved builtins/binary so the resolver's predicates
+	-- (unknown_of / has_local_config / binaries_of) and configure() share one probe.
+	local resolved = {}
+	local function info(source)
+		if resolved[source] == nil then
+			local builtins, binary = resolve_source(source)
+			resolved[source] = { builtins = builtins, binary = binary }
+		end
+		return resolved[source]
+	end
+
+	-- Discovery-first resolution, shared with LSP and DAP. For null-ls "configure"
+	-- means registering the builtin(s):
+	--   * Unknown source (no matching builtin)          -> mark_unknown (fix config).
+	--   * Pure-Lua builtin (no external binary)         -> register now (no install).
+	--   * Available (Mason-installed / binary on $PATH) -> register now.
+	--   * Not available but Mason ships a package       -> install, register on done.
+	--   * No Mason package and not on $PATH             -> ask the user to install it.
+	tools.resolve({
+		title = "null-ls",
+		deps = null_ls_deps,
+		registry = mason_ok and mason_registry or nil,
+		package_of = function(source)
+			return mason_ok and source_map.getPackageFromNullLs(source) or nil
+		end,
+		binaries_of = function(source)
+			local binary = info(source).binary
+			return binary and { binary } or {}
+		end,
+		unknown_of = function(source)
+			return #info(source).builtins == 0
+		end,
+		has_local_config = function(source)
+			local i = info(source)
+			-- A pure-Lua builtin (has builtins, no external command) needs no install.
+			return #i.builtins > 0 and i.binary == nil
+		end,
+		configure = function(source)
+			register(source, info(source).builtins)
+		end,
 	})
 end
 

--- a/lua/modules/configs/completion/mason-null-ls.lua
+++ b/lua/modules/configs/completion/mason-null-ls.lua
@@ -55,12 +55,23 @@ M.setup = function()
 	---prettier with custom filetypes/args), which run before this resolver.
 	---@param source string
 	---@param builtins table[]
-	local function register(source, builtins)
+	---@param binary string|nil @The command the builtin spawns (from resolve_source).
+	local function register(source, builtins, binary)
 		if null_ls.is_registered(source) then
 			return
 		end
+		-- A Mason install with PATH integration disabled (`PATH = "skip"`) leaves
+		-- the binary resolvable only inside Mason's bin dir: the resolver deems the
+		-- source available (`is_installed()`), but none-ls would spawn the bare
+		-- command name and fail. Rewrite the command to the absolute path
+		-- find_executable resolves (it probes Mason's bin dir after $PATH); when
+		-- the bare name already works — or nothing resolves — register untouched.
+		local command = nil
+		if binary and vim.fn.executable(binary) ~= 1 then
+			command = tools.find_executable(binary)
+		end
 		for _, builtin in ipairs(builtins) do
-			null_ls.register(builtin)
+			null_ls.register(command and builtin.with({ command = command }) or builtin)
 		end
 	end
 
@@ -108,7 +119,8 @@ M.setup = function()
 			return #i.builtins > 0 and i.binary == nil
 		end,
 		configure = function(source)
-			register(source, info(source).builtins)
+			local i = info(source)
+			register(source, i.builtins, i.binary)
 		end,
 	})
 end

--- a/lua/modules/configs/completion/mason-null-ls.lua
+++ b/lua/modules/configs/completion/mason-null-ls.lua
@@ -87,7 +87,13 @@ M.setup = function()
 		deps = null_ls_deps,
 		registry = mason_ok and mason_registry or nil,
 		package_of = function(source)
-			return mason_ok and source_map.getPackageFromNullLs(source) or nil
+			-- `mason_ok` only proves the module loaded; guard the private function too
+			-- so a mason-null-ls version that renames it degrades to $PATH resolution
+			-- instead of throwing out of the resolver.
+			if not mason_ok or type(source_map.getPackageFromNullLs) ~= "function" then
+				return nil
+			end
+			return source_map.getPackageFromNullLs(source)
 		end,
 		binaries_of = function(source)
 			local binary = info(source).binary

--- a/lua/modules/configs/completion/servers/html.lua
+++ b/lua/modules/configs/completion/servers/html.lua
@@ -1,6 +1,9 @@
--- https://github.com/vscode-langservers/vscode-html-languageserver-bin
+-- https://github.com/hrsh7th/vscode-langservers-extracted
 return {
-	cmd = { "html-languageserver", "--stdio" },
+	-- `html-languageserver` is the deprecated bin name; both Mason and current
+	-- distro packages ship `vscode-html-language-server`, which is also what the
+	-- resolver's $PATH probe must look for on Mason-less setups.
+	cmd = { "vscode-html-language-server", "--stdio" },
 	filetypes = { "html" },
 	init_options = {
 		configurationSection = { "html", "css", "javascript" },

--- a/lua/modules/configs/tool/dap/clients/codelldb.lua
+++ b/lua/modules/configs/tool/dap/clients/codelldb.lua
@@ -4,11 +4,19 @@ return function()
 	local utils = require("modules.utils.dap")
 	local is_windows = require("core.global").is_windows
 
+	-- Config-time self-validation: error out when codelldb isn't on $PATH so the
+	-- resolver in `tool/dap/init.lua` (which pcalls this config) surfaces `codelldb`
+	-- in the aggregated missing-tool warning — instead of registering an adapter
+	-- with an empty command that only fails once a debug session starts.
+	local command = vim.fn.exepath("codelldb")
+	if command == "" then
+		error("codelldb not found on $PATH; install it via Mason or your package manager")
+	end
 	dap.adapters.codelldb = {
 		type = "server",
 		port = "${port}",
 		executable = {
-			command = vim.fn.exepath("codelldb"), -- Find codelldb on $PATH
+			command = command,
 			args = { "--port", "${port}" },
 			detached = is_windows and false or true,
 		},

--- a/lua/modules/configs/tool/dap/clients/codelldb.lua
+++ b/lua/modules/configs/tool/dap/clients/codelldb.lua
@@ -7,18 +7,18 @@ return function()
 	-- Config-time self-validation: error out when codelldb isn't on $PATH so the
 	-- resolver in `tool/dap/init.lua` (which pcalls this config) surfaces `codelldb`
 	-- in the aggregated missing-tool warning — instead of registering an adapter
-	-- with an empty command that only fails once a debug session starts.
-	local command = vim.fn.exepath("codelldb")
-	if command == "" then
-		error("codelldb not found on $PATH; install it via Mason or your package manager")
-	end
+	-- with an empty command that only fails once a debug session starts. Every
+	-- codelldb branch (launch and attach) spawns the local binary, so unlike
+	-- delve/python there is no adapter worth registering without it.
+	local command =
+		require("modules.utils.tools").exepath_or_error("codelldb", "install it via Mason or your package manager")
 	dap.adapters.codelldb = {
 		type = "server",
 		port = "${port}",
 		executable = {
 			command = command,
 			args = { "--port", "${port}" },
-			detached = is_windows and false or true,
+			detached = not is_windows,
 		},
 	}
 	dap.configurations.c = {

--- a/lua/modules/configs/tool/dap/clients/delve.lua
+++ b/lua/modules/configs/tool/dap/clients/delve.lua
@@ -9,13 +9,10 @@ return function()
 	-- separate go-debug-adapter. This keeps Go debugging working wherever `dlv` is
 	-- available (system or Mason) and matches how `tool/dap/init.lua` resolves the
 	-- `delve` Mason package (bin `dlv`), so discovery/install and configuration agree
-	-- on a single binary. The resolver runs this under pcall, so erroring when `dlv`
-	-- is absent lets it mark `delve` as missing (with this message) instead of
-	-- configuring an adapter that can't launch.
-	local command = vim.fn.exepath("dlv")
-	if command == "" then
-		error("delve (dlv) not found on $PATH; install delve via Mason or your package manager")
-	end
+	-- on a single binary. `dlv` is resolved lazily on the spawn path only: a remote
+	-- `attach` connects to an already-running `dlv dap` and needs no local binary,
+	-- so the adapter must be registered even when `dlv` is absent (the availability
+	-- check at the end of this file surfaces that case without unregistering).
 
 	---Spawn `dlv dap` as a server adapter, binding to the port nvim-dap allocates.
 	---A function adapter (over a static table) so a remote `attach` config can
@@ -33,6 +30,12 @@ return function()
 				port = tonumber(config.port) or 38697,
 			})
 		else
+			-- Resolve lazily so a dlv installed after config load (a finished Mason
+			-- install, say) is picked up without reconfiguring.
+			local command = require("modules.utils.tools").find_executable("dlv")
+			if not command then
+				error("delve (dlv) not found on $PATH; install delve via Mason or your package manager", 0)
+			end
 			callback({
 				type = "server",
 				port = "${port}",
@@ -112,4 +115,16 @@ return function()
 			stopOnEntry = false,
 		},
 	}
+
+	-- Availability check LAST, after the adapter and configurations are registered:
+	-- erroring here lets the shared resolver surface `delve` in the aggregated
+	-- missing-tool warning (or fall back to a Mason install), while remote attach —
+	-- which needs no local dlv — keeps working with what was registered above.
+	if not require("modules.utils.tools").find_executable("dlv") then
+		error(
+			"delve (dlv) not found on $PATH; local `dlv dap` launch is unavailable until installed"
+				.. " (remote attach still works)",
+			0
+		)
+	end
 end

--- a/lua/modules/configs/tool/dap/clients/delve.lua
+++ b/lua/modules/configs/tool/dap/clients/delve.lua
@@ -1,31 +1,55 @@
--- https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go
+-- https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go-using-delve-directly
 -- https://github.com/golang/vscode-go/blob/master/docs/debugging.md
 return function()
 	local dap = require("dap")
 	local utils = require("modules.utils.dap")
+	local is_windows = require("core.global").is_windows
 
-	if not require("mason-registry").is_installed("go-debug-adapter") then
-		vim.notify(
-			"Automatically installing `go-debug-adapter` for go debugging",
-			vim.log.levels.INFO,
-			{ title = "nvim-dap" }
-		)
-
-		local go_dbg = require("mason-registry").get_package("go-debug-adapter")
-		go_dbg:install():once(
-			"closed",
-			vim.schedule_wrap(function()
-				if go_dbg:is_installed() then
-					vim.notify("Successfully installed `go-debug-adapter`", vim.log.levels.INFO, { title = "nvim-dap" })
-				end
-			end)
-		)
+	-- Use delve's built-in DAP server (`dlv dap`) directly as the adapter — no
+	-- separate go-debug-adapter. This keeps Go debugging working wherever `dlv` is
+	-- available (system or Mason) and matches how `tool/dap/init.lua` resolves the
+	-- `delve` Mason package (bin `dlv`), so discovery/install and configuration agree
+	-- on a single binary. The resolver runs this under pcall, so erroring when `dlv`
+	-- is absent lets it mark `delve` as missing (with this message) instead of
+	-- configuring an adapter that can't launch.
+	local command = vim.fn.exepath("dlv")
+	if command == "" then
+		error("delve (dlv) not found on $PATH; install delve via Mason or your package manager")
 	end
 
-	dap.adapters.go = {
-		type = "executable",
-		command = vim.fn.exepath("go-debug-adapter"), -- Find go-debug-adapter on $PATH
-	}
+	---Spawn `dlv dap` as a server adapter, binding to the port nvim-dap allocates.
+	---A function adapter (over a static table) so a remote `attach` config can
+	---connect to an already-running `dlv dap` instead of spawning a local one.
+	---@param callback fun(adapter: table)
+	---@param config table
+	local function delve_adapter(callback, config)
+		if config.request == "attach" and config.mode == "remote" then
+			callback({
+				type = "server",
+				host = config.host or "127.0.0.1",
+				-- Coerce to a number (and default to an integer): nvim-dap tonumber()s the
+				-- port itself, but a non-numeric user `config.port` would otherwise reach
+				-- the socket connect as-is; this guarantees an integer or the default.
+				port = tonumber(config.port) or 38697,
+			})
+		else
+			callback({
+				type = "server",
+				port = "${port}",
+				executable = {
+					command = command,
+					args = { "dap", "-l", "127.0.0.1:${port}" },
+					detached = not is_windows,
+				},
+			})
+		end
+	end
+
+	-- Register under both names: the configurations below use `type = "go"`, while
+	-- mason-nvim-dap / other integrations reference the adapter as `delve`.
+	dap.adapters.go = delve_adapter
+	dap.adapters.delve = delve_adapter
+
 	dap.configurations.go = {
 		{
 			type = "go",
@@ -34,7 +58,6 @@ return function()
 			cwd = "${workspaceFolder}",
 			program = utils.input_file_path(),
 			console = "integratedTerminal",
-			dlvToolPath = vim.fn.exepath("dlv"),
 			showLog = true,
 			showRegisters = true,
 			stopOnEntry = false,
@@ -47,7 +70,6 @@ return function()
 			program = utils.input_file_path(),
 			args = utils.input_args(),
 			console = "integratedTerminal",
-			dlvToolPath = vim.fn.exepath("dlv"),
 			showLog = true,
 			showRegisters = true,
 			stopOnEntry = false,
@@ -60,7 +82,6 @@ return function()
 			program = utils.input_exec_path(),
 			args = utils.input_args(),
 			console = "integratedTerminal",
-			dlvToolPath = vim.fn.exepath("dlv"),
 			mode = "exec",
 			showLog = true,
 			showRegisters = true,
@@ -73,7 +94,6 @@ return function()
 			cwd = "${workspaceFolder}",
 			program = utils.input_file_path(),
 			console = "integratedTerminal",
-			dlvToolPath = vim.fn.exepath("dlv"),
 			mode = "test",
 			showLog = true,
 			showRegisters = true,
@@ -86,7 +106,6 @@ return function()
 			cwd = "${workspaceFolder}",
 			program = "./${relativeFileDirname}",
 			console = "integratedTerminal",
-			dlvToolPath = vim.fn.exepath("dlv"),
 			mode = "test",
 			showLog = true,
 			showRegisters = true,

--- a/lua/modules/configs/tool/dap/clients/delve.lua
+++ b/lua/modules/configs/tool/dap/clients/delve.lua
@@ -24,9 +24,11 @@ return function()
 			callback({
 				type = "server",
 				host = config.host or "127.0.0.1",
-				-- Coerce to a number (and default to an integer): nvim-dap tonumber()s the
-				-- port itself, but a non-numeric user `config.port` would otherwise reach
-				-- the socket connect as-is; this guarantees an integer or the default.
+				-- nvim-dap asserts tonumber(adapter.port) before its socket connect, so
+				-- a non-numeric port could never reach the connect as-is; this coercion
+				-- is about accepting a string user `config.port` and supplying delve's
+				-- default 38697 when the value is absent or non-numeric (instead of
+				-- tripping that assert with a less actionable message).
 				port = tonumber(config.port) or 38697,
 			})
 		else

--- a/lua/modules/configs/tool/dap/clients/lldb.lua
+++ b/lua/modules/configs/tool/dap/clients/lldb.lua
@@ -3,9 +3,17 @@ return function()
 	local dap = require("dap")
 	local utils = require("modules.utils.dap")
 
+	-- Self-validate the binary so the shared resolver (which pcalls this config)
+	-- surfaces `lldb` in the aggregated missing-tool warning instead of registering
+	-- an adapter with an empty command that only fails at debug time.
+	local command = vim.fn.exepath("lldb-vscode")
+	if command == "" then
+		error("lldb-vscode not found on $PATH; install it via your package manager (ships with LLVM/lldb)")
+	end
+
 	dap.adapters.lldb = {
 		type = "executable",
-		command = vim.fn.exepath("lldb-vscode"), -- Find lldb-vscode on $PATH
+		command = command,
 	}
 	dap.configurations.c = {
 		{

--- a/lua/modules/configs/tool/dap/clients/lldb.lua
+++ b/lua/modules/configs/tool/dap/clients/lldb.lua
@@ -5,11 +5,13 @@ return function()
 
 	-- Self-validate the binary so the shared resolver (which pcalls this config)
 	-- surfaces `lldb` in the aggregated missing-tool warning instead of registering
-	-- an adapter with an empty command that only fails at debug time.
-	local command = vim.fn.exepath("lldb-vscode")
-	if command == "" then
-		error("lldb-vscode not found on $PATH; install it via your package manager (ships with LLVM/lldb)")
-	end
+	-- an adapter with an empty command that only fails at debug time. LLVM 15
+	-- renamed the DAP binary `lldb-vscode` -> `lldb-dap`; probe the current name
+	-- first and keep the old one for distros still shipping it.
+	local command = require("modules.utils.tools").exepath_or_error(
+		{ "lldb-dap", "lldb-vscode" },
+		"install it via your package manager (ships with LLVM/lldb)"
+	)
 
 	dap.adapters.lldb = {
 		type = "executable",

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -4,7 +4,48 @@ return function()
 	local dap = require("dap")
 	local utils = require("modules.utils.dap")
 	local is_windows = require("core.global").is_windows
-	local debugpy_root = vim.fn.expand("$MASON/packages/debugpy")
+	-- Resolve Mason's install root via the settings API (nil when Mason isn't
+	-- available), not the $MASON env var alone — it's only set as a side effect of
+	-- mason.setup() and may not be exported.
+	local mason_root = require("modules.utils.tools").mason_root()
+	local debugpy_root = mason_root and (mason_root .. "/packages/debugpy") or nil
+
+	-- Resolve the debugpy adapter command discovery-first: prefer Mason's managed
+	-- venv, then a `debugpy-adapter` on $PATH, then a system python running the
+	-- debugpy module. This keeps python debugging working without Mason (BSD/NixOS),
+	-- where the hard-coded Mason path would otherwise point at a missing directory.
+	-- Returns nil when nothing resolves (no guessing).
+	local function debugpy_command()
+		if debugpy_root then
+			local mason_python = is_windows and debugpy_root .. "/venv/Scripts/pythonw.exe"
+				or debugpy_root .. "/venv/bin/python"
+			if vim.fn.executable(mason_python) == 1 then
+				return mason_python, { "-m", "debugpy.adapter" }
+			end
+		end
+		if vim.fn.executable("debugpy-adapter") == 1 then
+			return "debugpy-adapter", {}
+		end
+		-- Last resort: a python interpreter on $PATH that can run debugpy. Probe
+		-- candidates rather than hard-coding one, so we don't hand nvim-dap a
+		-- command that isn't installed (e.g. pythonw.exe is often absent on a
+		-- Windows box that only has python.exe / python).
+		local candidates = is_windows and { "pythonw.exe", "python.exe", "python" } or { "python3", "python" }
+		for _, py in ipairs(candidates) do
+			-- `executable(py) == 1` only proves the interpreter exists, not that it can
+			-- run debugpy. Confirm the module imports (list-form system() call, no
+			-- shell) so we don't hand nvim-dap a python that fails only once a debug
+			-- session starts — this is what the self-validation error() below promises
+			-- ("python with the debugpy module on $PATH").
+			if vim.fn.executable(py) == 1 then
+				vim.fn.system({ py, "-c", "import debugpy" })
+				if vim.v.shell_error == 0 then
+					return py, { "-m", "debugpy.adapter" }
+				end
+			end
+		end
+		return nil
+	end
 
 	dap.adapters.python = function(callback, config)
 		if config.request == "attach" then
@@ -17,11 +58,22 @@ return function()
 				options = { source_filetype = "python" },
 			})
 		else
+			-- Resolve debugpy lazily, on the launch path only: an `attach` session uses
+			-- the server adapter above and needs no local debugpy, so validating at
+			-- config load would wrongly make remote attach impossible. Still fail fast
+			-- here with a clear error (never a guessed / empty command) when a launch is
+			-- actually requested and debugpy can't be resolved.
+			local command, args = debugpy_command()
+			if not command then
+				error(
+					"debugpy not found: no Mason venv, `debugpy-adapter`, or python with the debugpy\n"
+						.. "module on $PATH; install debugpy via Mason (`:Mason`) or your package manager"
+				)
+			end
 			callback({
 				type = "executable",
-				command = is_windows and debugpy_root .. "/venv/Scripts/pythonw.exe"
-					or debugpy_root .. "/venv/bin/python",
-				args = { "-m", "debugpy.adapter" },
+				command = command,
+				args = args,
 				options = { source_filetype = "python" },
 			})
 		end

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -80,7 +80,8 @@ return function()
 			if not command then
 				error(
 					"debugpy not found: no Mason venv, `debugpy-adapter`, or python with the debugpy\n"
-						.. "module on $PATH; install debugpy via Mason (`:Mason`) or your package manager"
+						.. "module on $PATH; install debugpy via Mason (`:Mason`) or your package manager",
+					0
 				)
 			end
 			callback({

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -69,11 +69,13 @@ return function()
 				options = { source_filetype = "python" },
 			})
 		else
-			-- Resolve debugpy lazily, on the launch path only: an `attach` session uses
-			-- the server adapter above and needs no local debugpy, so validating at
-			-- config load would wrongly make remote attach impossible. Still fail fast
-			-- here with a clear error (never a guessed / empty command) when a launch is
-			-- actually requested and debugpy can't be resolved.
+			-- Gate debugpy on the launch path: an `attach` session uses the server
+			-- adapter above and needs no local debugpy, so a failed resolution must
+			-- never block attach. (The availability check at the end of this file also
+			-- probes at config load, but only after the adapter is registered — its
+			-- error() surfaces the missing tool without unregistering anything.) Fail
+			-- fast here with a clear error (never a guessed / empty command) when a
+			-- launch is actually requested and debugpy can't be resolved.
 			local command, args = debugpy_command()
 			if not command then
 				error(
@@ -139,8 +141,11 @@ return function()
 	-- erroring here lets the shared resolver surface `python` in the aggregated
 	-- missing-tool warning (or fall back to installing debugpy via Mason), while
 	-- remote attach — which needs no local debugpy — keeps working with what was
-	-- registered above. The successful probe is cached, so this shares its cost
-	-- with the first launch instead of adding to it.
+	-- registered above. This intentionally runs the discovery probe at config load —
+	-- that is the price of config-time self-validation, bounded by DAP config itself
+	-- being lazy (first dap command, not editor startup). On success the result is
+	-- cached and reused by the first launch; on failure it stays uncached so a
+	-- debugpy installed mid-session is picked up without reconfiguring.
 	if not debugpy_command() then
 		error(
 			"debugpy not found: no Mason venv, `debugpy-adapter`, or python with the debugpy\n"

--- a/lua/modules/configs/tool/dap/clients/python.lua
+++ b/lua/modules/configs/tool/dap/clients/python.lua
@@ -14,17 +14,28 @@ return function()
 	-- venv, then a `debugpy-adapter` on $PATH, then a system python running the
 	-- debugpy module. This keeps python debugging working without Mason (BSD/NixOS),
 	-- where the hard-coded Mason path would otherwise point at a missing directory.
-	-- Returns nil when nothing resolves (no guessing).
+	-- Returns nil when nothing resolves (no guessing). Only a *successful*
+	-- resolution is cached: the import probe below shells out (blocking), so
+	-- repeating it on every launch would stall the UI — while a failure must stay
+	-- re-probeable so a debugpy installed mid-session is picked up next launch.
+	local resolved
 	local function debugpy_command()
+		if resolved then
+			return resolved.command, resolved.args
+		end
+		local function found(command, args)
+			resolved = { command = command, args = args }
+			return command, args
+		end
 		if debugpy_root then
 			local mason_python = is_windows and debugpy_root .. "/venv/Scripts/pythonw.exe"
 				or debugpy_root .. "/venv/bin/python"
 			if vim.fn.executable(mason_python) == 1 then
-				return mason_python, { "-m", "debugpy.adapter" }
+				return found(mason_python, { "-m", "debugpy.adapter" })
 			end
 		end
 		if vim.fn.executable("debugpy-adapter") == 1 then
-			return "debugpy-adapter", {}
+			return found("debugpy-adapter", {})
 		end
 		-- Last resort: a python interpreter on $PATH that can run debugpy. Probe
 		-- candidates rather than hard-coding one, so we don't hand nvim-dap a
@@ -40,7 +51,7 @@ return function()
 			if vim.fn.executable(py) == 1 then
 				vim.fn.system({ py, "-c", "import debugpy" })
 				if vim.v.shell_error == 0 then
-					return py, { "-m", "debugpy.adapter" }
+					return found(py, { "-m", "debugpy.adapter" })
 				end
 			end
 		end
@@ -123,4 +134,18 @@ return function()
 			end,
 		},
 	}
+
+	-- Availability check LAST, after the adapter and configurations are registered:
+	-- erroring here lets the shared resolver surface `python` in the aggregated
+	-- missing-tool warning (or fall back to installing debugpy via Mason), while
+	-- remote attach — which needs no local debugpy — keeps working with what was
+	-- registered above. The successful probe is cached, so this shares its cost
+	-- with the first launch instead of adding to it.
+	if not debugpy_command() then
+		error(
+			"debugpy not found: no Mason venv, `debugpy-adapter`, or python with the debugpy\n"
+				.. "module on $PATH; local launch is unavailable until installed (remote attach still works)",
+			0
+		)
+	end
 end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -65,8 +65,19 @@ return function()
 			-- mason-nvim-dap is available.
 			if has_mason_dap then
 				mason_dap.default_setup(config)
+				return
 			end
-			return
+			-- No client config and no mason-nvim-dap to provide a default: nothing can
+			-- register this adapter. error() (level 0, no position prefix) so the shared
+			-- resolver — which pcalls configure — reports it in the aggregated warning
+			-- instead of treating a silent return as a successful setup.
+			error(
+				string.format(
+					"no client config under `tool/dap/clients/%s.lua` and mason-nvim-dap is unavailable for a default setup",
+					dap_name
+				),
+				0
+			)
 		elseif type(custom_handler) == "function" then
 			-- Case where the protocol requires its own setup
 			-- Make sure to set

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -1,7 +1,10 @@
 return function()
 	local dap = require("dap")
 	local dapui = require("dapui")
-	local mason_dap = require("mason-nvim-dap")
+	-- Mason is an optional installer backend: guard its require so a Mason-less
+	-- setup still configures adapters that resolve their own binary (client
+	-- configs / $PATH) instead of hard-erroring here.
+	local has_mason_dap, mason_dap = pcall(require, "mason-nvim-dap")
 
 	local icons = { dap = require("modules.utils.icons").get("dap") }
 	local colors = require("modules.utils").get_palette()
@@ -58,8 +61,11 @@ return function()
 			ok, custom_handler = pcall(require, "tool.dap.clients." .. dap_name)
 		end
 		if not ok then
-			-- Default to use factory config for clients(s) that doesn't include a spec
-			mason_dap.default_setup(config)
+			-- Default to Mason's factory config for clients without a spec, only when
+			-- mason-nvim-dap is available.
+			if has_mason_dap then
+				mason_dap.default_setup(config)
+			end
 			return
 		elseif type(custom_handler) == "function" then
 			-- Case where the protocol requires its own setup
@@ -81,9 +87,82 @@ return function()
 		end
 	end
 
-	require("modules.utils").load_plugin("mason-nvim-dap", {
-		ensure_installed = require("core.settings").dap_deps,
-		automatic_installation = false,
-		handlers = { mason_dap_handler },
+	local settings = require("core.settings")
+	local tools = require("modules.utils.tools")
+
+	-- Mason-driven bits (source/adapter mappings + install) are only available when
+	-- Mason is. Without it we still configure adapters that resolve their own binary
+	-- (client configs / $PATH). Either way we drive setup discovery-first rather than
+	-- letting mason-nvim-dap gate configuration on its installed set.
+	local has_registry, registry = pcall(require, "mason-registry")
+	local mason_ok = has_mason_dap and has_registry
+	local source_map = { nvim_dap_to_package = {} }
+	local adapters_map, configs_map, filetypes_map = {}, {}, {}
+	if mason_ok then
+		require("modules.utils").load_plugin("mason-nvim-dap", {
+			ensure_installed = {},
+			automatic_installation = false,
+		})
+		-- These are mason-nvim-dap's private internals, not a public API: guard each
+		-- require so a version that renames/removes one degrades to client-config /
+		-- $PATH resolution instead of aborting the entire dap config.
+		local function map_or_empty(mod, default)
+			local ok, m = pcall(require, mod)
+			return (ok and type(m) == "table") and m or default
+		end
+		source_map = map_or_empty("mason-nvim-dap.mappings.source", { nvim_dap_to_package = {} })
+		adapters_map = map_or_empty("mason-nvim-dap.mappings.adapters", {})
+		configs_map = map_or_empty("mason-nvim-dap.mappings.configurations", {})
+		filetypes_map = map_or_empty("mason-nvim-dap.mappings.filetypes", {})
+	end
+
+	---Does an explicit client config exist for this adapter (system-resolved)?
+	---@param name string
+	---@return boolean
+	local function has_client_config(name)
+		for _, module in ipairs({ "user.configs.dap-clients." .. name, "tool.dap.clients." .. name }) do
+			if pcall(require, module) then
+				return true
+			end
+		end
+		return false
+	end
+
+	---Configure an adapter via the shared handler (client config or default_setup).
+	---Each client config self-validates its binary and `error()`s when it can't be
+	---resolved, which the shared resolver surfaces as missing (with the message) —
+	---so there is no separate post-config sanity check here.
+	---@param name string
+	local function configure_adapter(name)
+		mason_dap_handler({
+			name = name,
+			adapters = adapters_map[name],
+			configurations = configs_map[name],
+			filetypes = filetypes_map[name],
+		})
+	end
+
+	-- Discovery-first resolution, shared with LSP and null-ls:
+	--   * Available now (Mason-installed / on $PATH) or backed by a client config
+	--     -> configure now (the client config resolves its own binary and errors
+	--     out if absent, surfaced via the aggregated warning).
+	--   * Mason ships a package but it isn't available yet -> install, then
+	--     configure on completion (never configured with an unresolved binary).
+	--   * Neither -> ask the user to install it.
+	-- nvim-dap has no uniform command registry like nvim-lspconfig, so $PATH
+	-- detection leans on the Mason package's declared binaries; client configs
+	-- without a Mason package resolve their own binary.
+	tools.resolve({
+		title = "DAP",
+		deps = settings.dap_deps,
+		registry = mason_ok and registry or nil,
+		package_of = function(name)
+			return source_map.nvim_dap_to_package[name]
+		end,
+		binaries_of = function(name, pkg)
+			return pkg ~= nil and tools.package_binaries(pkg, source_map.nvim_dap_to_package[name] or name) or {}
+		end,
+		has_local_config = has_client_config,
+		configure = configure_adapter,
 	})
 end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -114,6 +114,11 @@ return function()
 		adapters_map = map_or_empty("mason-nvim-dap.mappings.adapters", {})
 		configs_map = map_or_empty("mason-nvim-dap.mappings.configurations", {})
 		filetypes_map = map_or_empty("mason-nvim-dap.mappings.filetypes", {})
+		-- The module may load while the field we index is renamed/removed (the require
+		-- guard can't see that); normalize so package_of/binaries_of below never index nil.
+		if type(source_map.nvim_dap_to_package) ~= "table" then
+			source_map.nvim_dap_to_package = {}
+		end
 	end
 
 	---Does an explicit client config exist for this adapter (system-resolved)?
@@ -160,9 +165,21 @@ return function()
 			return source_map.nvim_dap_to_package[name]
 		end,
 		binaries_of = function(name, pkg)
-			return pkg ~= nil and tools.package_binaries(pkg, source_map.nvim_dap_to_package[name] or name) or {}
+			if pkg ~= nil then
+				return tools.package_binaries(pkg, source_map.nvim_dap_to_package[name] or name)
+			end
+			-- No Package object (Mason absent, or the mapping points at a package the
+			-- registry doesn't know): probe the mapped package name / adapter name
+			-- directly, so an adapter provided by the system is still discovered
+			-- instead of being misreported as an unknown name.
+			return { source_map.nvim_dap_to_package[name] or name }
 		end,
 		has_local_config = has_client_config,
+		-- Client configs self-validate (error() when their binary can't be resolved),
+		-- so the resolver lets an existing config try before falling back to a Mason
+		-- install — e.g. python resolves debugpy from a venv/system interpreter that
+		-- the $PATH probe can't see.
+		validates_config = true,
 		configure = configure_adapter,
 	})
 end

--- a/lua/modules/configs/tool/dap/init.lua
+++ b/lua/modules/configs/tool/dap/init.lua
@@ -177,7 +177,10 @@ return function()
 		end,
 		binaries_of = function(name, pkg)
 			if pkg ~= nil then
-				return tools.package_binaries(pkg, source_map.nvim_dap_to_package[name] or name)
+				-- package_binaries prefers pkg.name when the spec declares no bin table,
+				-- so the adapter name is only the last resort (adapter != package name,
+				-- e.g. python -> debugpy).
+				return tools.package_binaries(pkg, name)
 			end
 			-- No Package object (Mason absent, or the mapping points at a package the
 			-- registry doesn't know): probe the mapped package name / adapter name

--- a/lua/modules/plugins/completion.lua
+++ b/lua/modules/plugins/completion.lua
@@ -51,6 +51,10 @@ completion["nvimtools/none-ls.nvim"] = {
 	dependencies = {
 		"nvim-lua/plenary.nvim",
 		"jay-babu/mason-null-ls.nvim",
+		-- mason.nvim is command-lazy; declare it here so it's on the runtimepath
+		-- before this config's discovery-first resolver runs, otherwise Mason
+		-- support hinges on plugin load order (the mason-registry require can fail).
+		"mason-org/mason.nvim",
 	},
 }
 completion["saghen/blink.cmp"] = {

--- a/lua/modules/plugins/tool.lua
+++ b/lua/modules/plugins/tool.lua
@@ -148,6 +148,10 @@ tool["mfussenegger/nvim-dap"] = {
 	config = require("tool.dap"),
 	dependencies = {
 		{ "jay-babu/mason-nvim-dap.nvim" },
+		-- mason.nvim is command-lazy; declare it here so it's on the runtimepath
+		-- before this config's discovery-first resolver runs, otherwise Mason
+		-- support hinges on plugin load order (the mason-registry require can fail).
+		{ "mason-org/mason.nvim" },
 		{
 			"rcarriga/nvim-dap-ui",
 			dependencies = "nvim-neotest/nvim-nio",

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -542,13 +542,17 @@ function M.resolve(spec)
 
 	local function run()
 		local visited = {}
-		for _, name in ipairs(spec.deps) do
+		-- maxn, not ipairs (see any_executable): a nil hole from a conditional
+		-- entry (`cond and "foo" or nil`) must skip that slot, not end resolution
+		-- for every dep after it.
+		for i = 1, table.maxn(spec.deps) do
+			local name = spec.deps[i]
 			-- Dedup (a name listed twice would double-install/configure and double up
 			-- the "Installing N tool(s)" list) and isolate: one dep's failure — a
 			-- non-string entry, or a subsystem callback tripping on plugin-version
 			-- drift (a renamed mapping field, say) — must not abort resolution of the
 			-- remaining deps or suppress the aggregated warning.
-			if not visited[name] then
+			if name ~= nil and not visited[name] then
 				visited[name] = true
 				local ok, err = pcall(resolve_one, name)
 				if not ok then
@@ -598,8 +602,8 @@ function M.resolve(spec)
 				return
 			end
 			settled = true
-			for _, name in ipairs(spec.deps) do
-				collector.mark(name, "Mason registry refresh did not complete (cannot resolve or install)")
+			for i = 1, table.maxn(spec.deps) do
+				collector.mark(spec.deps[i], "Mason registry refresh did not complete (cannot resolve or install)")
 			end
 			collector.done()
 		end, 300000)

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -557,11 +557,40 @@ function M.resolve(spec)
 		-- Fresh (never-bootstrapped) setup: wait for refresh() to download the
 		-- package specs. It calls back from a fast event context when it actually
 		-- updates; defer to the main loop only then.
+		--
+		-- refresh() only calls back on completion or failure — a *stalled*
+		-- transfer (hung network on a first-ever launch) fires neither, and
+		-- resolution would then never run: nothing gets configured and nothing is
+		-- surfaced, for the whole session. Arm a deadline that reports the deps as
+		-- unresolved instead of staying silent; `settled` makes callback and
+		-- deadline mutually exclusive (a refresh completing after the deadline is
+		-- dropped — the warning already told the user, and a relaunch retries).
+		local settled = false
+		local function on_refreshed()
+			if settled then
+				return
+			end
+			settled = true
+			run()
+		end
+		vim.defer_fn(function()
+			if settled then
+				return
+			end
+			settled = true
+			for _, name in ipairs(spec.deps) do
+				collector.mark(
+					type(name) == "string" and name or tostring(name),
+					"Mason registry refresh did not complete (cannot resolve or install)"
+				)
+			end
+			collector.done()
+		end, 300000)
 		registry.refresh(function()
 			if vim.in_fast_event() then
-				vim.schedule(run)
+				vim.schedule(on_refreshed)
 			else
-				run()
+				on_refreshed()
 			end
 		end)
 	else

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -19,6 +19,10 @@ local M = {}
 local installing = {}
 
 ---Return true if any of the given executable names is found on $PATH.
+---Semantics are intentionally *any*, not *all*: callers pass either the single
+---binary a tool launches with, or a Mason package's declared bins (which appear
+---together once installed) — requiring all would false-negative packages that
+---declare auxiliary binaries.
 ---@param names string|string[] @A single executable name or a list of them.
 ---@return boolean
 function M.any_executable(names)
@@ -34,6 +38,56 @@ function M.any_executable(names)
 		end
 	end
 	return false
+end
+
+---Locate the first of the given executables: on $PATH, then in Mason's bin
+---directory. The latter covers a Mason install with PATH integration disabled
+---(`PATH = "skip"`), where `is_installed()` is true but a plain exepath() finds
+---nothing — without it the resolver would deem such a tool available and its
+---config would then wrongly report it missing.
+---@param names string|string[] @Executable name(s), probed in order.
+---@return string|nil @Absolute path of the first name found, or nil.
+function M.find_executable(names)
+	if type(names) == "string" then
+		names = { names }
+	end
+	for _, name in ipairs(names) do
+		local path = vim.fn.exepath(name)
+		if path ~= "" then
+			return path
+		end
+	end
+	local root = M.mason_root()
+	if root then
+		for _, name in ipairs(names) do
+			-- exepath() on an absolute candidate validates executability and resolves
+			-- the extension on Windows (mason bin shims are `<name>.cmd` there).
+			local path = vim.fn.exepath(root .. "/bin/" .. name)
+			if path ~= "" then
+				return path
+			end
+		end
+	end
+	return nil
+end
+
+---Resolve the first of the given executable names (see `find_executable`), or
+---`error()` with an install hint. Client/server configs use this for config-time
+---self-validation: the shared resolver pcalls them and surfaces the message in
+---the aggregated missing-tool warning. Thrown at level 0 so the message arrives
+---without a "file:line:" prefix (no fragile stripping needed downstream).
+---@param names string|string[] @Executable name(s), probed in order.
+---@param hint string @Actionable install guidance appended to the error.
+---@return string @Absolute path of the first name found.
+function M.exepath_or_error(names, hint)
+	if type(names) == "string" then
+		names = { names }
+	end
+	local path = M.find_executable(names)
+	if path then
+		return path
+	end
+	error(string.format("%s not found on $PATH; %s", table.concat(names, "/"), hint), 0)
 end
 
 ---Create a collector that aggregates tools which could not be set up automatically
@@ -142,6 +196,21 @@ function M.missing_collector(title)
 		track = function(pkg, name, recheck, on_ready)
 			local pkg_name = type(pkg) == "table" and pkg.name or nil
 			local handle = pkg_name and installing[pkg_name] or nil
+
+			-- A cached handle may already be closed: mason emits "closed" synchronously
+			-- while our cache is only cleared on the next tick (schedule_wrap), and its
+			-- EventEmitter neither replays past events nor keeps handlers after close —
+			-- a `once()` on it would never fire and leak `pending` (suppressing the
+			-- aggregated warning forever). Drop it and resolve a fresh handle instead.
+			if handle then
+				local ok_closed, closed = pcall(function()
+					return handle:is_closed()
+				end)
+				if not ok_closed or closed then
+					installing[pkg_name] = nil
+					handle = nil
+				end
+			end
 
 			-- Already being installed elsewhere: reuse its handle so we still run
 			-- recheck()/on_ready() when it finishes, without starting a duplicate
@@ -295,19 +364,24 @@ end
 ---  0. Unrecognized name (`unknown_of`)          -> ask the user to fix the config
 ---     (a null-ls source with no matching builtin, say); never install.
 ---  1. Available now (Mason-installed or a binary on $PATH) -> configure now.
----  2. Not available but a Mason package exists   -> install, then configure on
----     completion (never configured with an unresolved binary).
+---  2. Not available but a Mason package exists   -> when `validates_config` is
+---     set and a local config exists, let the config try first (it is its own
+---     resolver and `error()`s when it can't); otherwise (or when that fails)
+---     install, then configure on completion (never configured with an
+---     unresolved binary).
 ---  3. No Mason package but a local config exists -> configure now; the
 ---     client/server config self-validates its binary and `error()`s if absent,
 ---     surfaced (with the message) as missing. A pure-Lua null-ls builtin (no
 ---     external binary) also lands here and is registered directly.
 ---  4. Otherwise                                  -> ask the user to install it
----     (or `mark_unknown` when the Mason mapping is stale).
+---     (or `mark_unknown` when the Mason mapping is stale AND no binary is known
+---     — with a known binary the guidance stays "install it").
 ---
----The whole loop runs inside `registry.refresh(...)` so Mason's package specs /
----mappings are loaded even on a fresh (never-bootstrapped) setup; without a
----registry it runs immediately. `configure` is optional (formatters/linters just
----install-or-warn) and is always pcall'd so one failing setup can't abort the rest.
+---Resolution runs synchronously whenever the registry is bootstrapped (or absent):
+---lazy-loaded subsystems (DAP after `:DapContinue`) need their tools registered in
+---the same tick. Only a fresh, never-bootstrapped registry defers to `refresh()`.
+---`configure` is optional (formatters/linters just install-or-warn) and always
+---pcall'd — as is each dep's resolution — so one failure can't abort the rest.
 ---@param spec {
 ---  title: string,
 ---  deps: string[],
@@ -316,27 +390,44 @@ end
 ---  binaries_of: fun(name: string, pkg: table|nil): string[],
 ---  unknown_of?: fun(name: string): boolean,
 ---  has_local_config?: fun(name: string): boolean,
+---  validates_config?: boolean,
 ---  configure?: fun(name: string),
 ---}
 function M.resolve(spec)
 	local collector = M.missing_collector(spec.title)
 	local registry = spec.registry
 
-	-- Configure one tool, surfacing a config-time error (e.g. a client config that
-	-- can't find its binary) as a missing entry annotated with the error message.
-	local function do_configure(name)
+	-- Strip Lua's "chunkname:line: " position prefix that a bare `error(msg)` adds,
+	-- so the aggregated warning reads "delve — dlv not found …" rather than
+	-- "delve — …/delve.lua:17: dlv not found …". Errors thrown with `error(msg, 0)`
+	-- (e.g. via M.exepath_or_error) arrive unprefixed and pass through untouched.
+	local function strip_position(err)
+		if type(err) ~= "string" then
+			return nil
+		end
+		return (err:gsub("^[^\n]-:%d+: ", ""))
+	end
+
+	---Configure one tool. Returns true on success; false plus the cleaned error
+	---message when the config threw (e.g. a client config that can't resolve its
+	---binary). Callers decide whether a failure is final (mark missing) or a
+	---fallback trigger (try a Mason install instead).
+	local function try_configure(name)
 		if type(spec.configure) ~= "function" then
-			return
+			return true
 		end
 		local ok, err = pcall(spec.configure, name)
+		if ok then
+			return true
+		end
+		return false, strip_position(err)
+	end
+
+	-- Configure one tool, surfacing a config-time error as a missing entry
+	-- annotated with the error message.
+	local function do_configure(name)
+		local ok, reason = try_configure(name)
 		if not ok then
-			local reason
-			if type(err) == "string" then
-				-- Strip Lua's "chunkname:line: " position prefix that `error(msg)` adds,
-				-- so the aggregated warning reads "delve — dlv not found …" rather than
-				-- "delve — …/delve.lua:17: dlv not found …".
-				reason = (err:gsub("^[^\n]-:%d+: ", ""))
-			end
 			collector.mark(name, reason)
 		end
 	end
@@ -370,6 +461,18 @@ function M.resolve(spec)
 		-- only configure once the binary is available, so an adapter/server is never
 		-- registered with an empty command.
 		if not available and pkg ~= nil then
+			-- When the subsystem's configs self-validate (`validates_config`), a local
+			-- config is itself a discovery-first resolver (venv, system interpreter,
+			-- module import, ...) that can succeed even though the $PATH probe found
+			-- nothing — e.g. a pip-installed debugpy with no console script. Let it
+			-- try before falling back to a Mason install, so an already-usable tool
+			-- isn't gated behind a download; its `error()` means "couldn't resolve"
+			-- and falls through to the install below.
+			if spec.validates_config and spec.has_local_config and spec.has_local_config(name) then
+				if try_configure(name) then
+					return
+				end
+			end
 			collector.track(pkg, name, function()
 				return pkg:is_installed() or M.any_executable(spec.binaries_of(name, pkg))
 			end, function()
@@ -385,7 +488,10 @@ function M.resolve(spec)
 		-- builtin (no binary, `has_local_config` true) is likewise registered here.
 		if available or (spec.has_local_config and spec.has_local_config(name)) then
 			do_configure(name)
-		elseif pkg_unknown then
+		elseif pkg_unknown and #binaries == 0 then
+			-- Only report a stale/unknown Mason mapping when there is no other evidence
+			-- the tool is real; when its binary is known, the actionable fix is to
+			-- install it (mark below), not to edit the config.
 			collector.mark_unknown(pkg_name == name and name or (pkg_name .. " (for " .. name .. ")"))
 		else
 			collector.mark(name)
@@ -393,18 +499,42 @@ function M.resolve(spec)
 	end
 
 	local function run()
+		local visited = {}
 		for _, name in ipairs(spec.deps) do
-			resolve_one(name)
+			-- Dedup (a name listed twice would double-install/configure and double up
+			-- the "Installing N tool(s)" list) and isolate: one dep's failure — a
+			-- non-string entry, or a subsystem callback tripping on plugin-version
+			-- drift (a renamed mapping field, say) — must not abort resolution of the
+			-- remaining deps or suppress the aggregated warning.
+			if not visited[name] then
+				visited[name] = true
+				local ok, err = pcall(resolve_one, name)
+				if not ok then
+					collector.mark(type(name) == "string" and name or tostring(name), strip_position(err))
+				end
+			end
 		end
 		collector.done()
 	end
 
-	if registry and type(registry.refresh) == "function" then
-		-- refresh() calls back synchronously when the cache is fresh (the common
-		-- case) and asynchronously — from a fast event context — when it actually
-		-- updates. Defer to the main loop only in the latter case so synchronous
-		-- resolution (e.g. DAP adapters needed immediately after `:DapContinue`)
-		-- isn't needlessly pushed to the next tick.
+	-- A bootstrapped registry (sources already on disk) is usable even when its
+	-- cache is stale — refresh() would only be a background freshness update, and
+	-- waiting for it turns resolution asynchronous: lazy.nvim replays the trigger
+	-- command (e.g. `:DapContinue`) in the same tick the plugin config runs, so
+	-- adapters/servers must be registered synchronously or the first invocation
+	-- no-ops. Only gate on refresh() when the registry has never been bootstrapped
+	-- (package specs aren't on disk yet, so there is nothing to resolve against).
+	local function registry_bootstrapped()
+		local ok, all_installed = pcall(function()
+			return registry.sources ~= nil and registry.sources:is_all_installed()
+		end)
+		return ok and all_installed == true
+	end
+
+	if registry and type(registry.refresh) == "function" and not registry_bootstrapped() then
+		-- Fresh (never-bootstrapped) setup: wait for refresh() to download the
+		-- package specs. It calls back from a fast event context when it actually
+		-- updates; defer to the main loop only then.
 		registry.refresh(function()
 			if vim.in_fast_event() then
 				vim.schedule(run)

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -51,20 +51,30 @@ function M.find_executable(names)
 	if type(names) == "string" then
 		names = { names }
 	end
+	-- Mirror any_executable's input hygiene: exepath() throws on non-string and
+	-- empty-string arguments (E1174/E1175), so returning nil / skipping bad
+	-- entries keeps a malformed call resolving as "not found" instead of erroring.
+	if type(names) ~= "table" then
+		return nil
+	end
 	for _, name in ipairs(names) do
-		local path = vim.fn.exepath(name)
-		if path ~= "" then
-			return path
+		if type(name) == "string" and name ~= "" then
+			local path = vim.fn.exepath(name)
+			if path ~= "" then
+				return path
+			end
 		end
 	end
 	local root = M.mason_root()
 	if root then
 		for _, name in ipairs(names) do
-			-- exepath() on an absolute candidate validates executability and resolves
-			-- the extension on Windows (mason bin shims are `<name>.cmd` there).
-			local path = vim.fn.exepath(root .. "/bin/" .. name)
-			if path ~= "" then
-				return path
+			if type(name) == "string" and name ~= "" then
+				-- exepath() on an absolute candidate validates executability and resolves
+				-- the extension on Windows (mason bin shims are `<name>.cmd` there).
+				local path = vim.fn.exepath(root .. "/bin/" .. name)
+				if path ~= "" then
+					return path
+				end
 			end
 		end
 	end
@@ -87,7 +97,19 @@ function M.exepath_or_error(names, hint)
 	if path then
 		return path
 	end
-	error(string.format("%s not found on $PATH; %s", table.concat(names, "/"), hint), 0)
+	-- Render only well-formed entries (find_executable skipped the rest):
+	-- table.concat throws on tables/booleans/nil holes, which would replace the
+	-- actionable message below with an unrelated concat error.
+	local shown = {}
+	if type(names) == "table" then
+		for _, name in ipairs(names) do
+			if type(name) == "string" and name ~= "" then
+				shown[#shown + 1] = name
+			end
+		end
+	end
+	local label = #shown > 0 and table.concat(shown, "/") or "<invalid executable spec>"
+	error(string.format("%s not found on $PATH; %s", label, hint), 0)
 end
 
 ---Create a collector that aggregates tools which could not be set up automatically

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -362,9 +362,12 @@ function M.missing_collector(title)
 end
 
 ---Collect the executable name(s) a Mason package provides, from its spec.
----Falls back to the package name when the spec declares no `bin` table.
+---When the spec declares no `bin` table, falls back to the package's own name
+---(`pkg.name`) before the caller-supplied name: the caller's subsystem name can
+---differ from the package name (adapter `python` -> package `debugpy`), and the
+---package name is the better probe for what an install would provide.
 ---@param pkg table @A mason-registry Package object.
----@param fallback string @Name to use when `pkg.spec.bin` is absent.
+---@param fallback string @Last-resort name when even `pkg.name` is absent.
 ---@return string[]
 function M.package_binaries(pkg, fallback)
 	local bins = {}
@@ -374,7 +377,7 @@ function M.package_binaries(pkg, fallback)
 		end
 	end
 	if #bins == 0 then
-		bins = { fallback }
+		bins = { type(pkg.name) == "string" and pkg.name or fallback }
 	end
 	return bins
 end

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -143,11 +143,20 @@ function M.missing_collector(title)
 	local pending = 0
 	local flushed = false
 
-	-- Record a name into a bucket once: ignore non-strings/empties and de-duplicate
-	-- (across both buckets) so the aggregated notification stays stable regardless
-	-- of how callers invoke it.
+	-- Record a name into a bucket once, de-duplicated across both buckets so the
+	-- aggregated notification stays stable regardless of how callers invoke it.
+	-- A non-string name (a malformed deps entry: a number, a nested table) is
+	-- coerced via tostring() so it is still surfaced as a config error instead of
+	-- silently vanishing from the warning; nil and empty strings stay ignored
+	-- (nothing meaningful to render).
+	local function normalize(name)
+		if name == nil or name == "" then
+			return nil
+		end
+		return type(name) == "string" and name or tostring(name)
+	end
 	local function record(bucket, name)
-		if type(name) ~= "string" or name == "" or seen[name] then
+		if name == nil or seen[name] then
 			return false
 		end
 		seen[name] = true
@@ -155,12 +164,13 @@ function M.missing_collector(title)
 		return true
 	end
 	local function add(name, reason)
+		name = normalize(name)
 		if record(missing, name) and type(reason) == "string" and reason ~= "" then
 			reasons[name] = reason
 		end
 	end
 	local function add_unknown(name)
-		record(unknown, name)
+		record(unknown, normalize(name))
 	end
 
 	local function render(name)
@@ -532,7 +542,7 @@ function M.resolve(spec)
 				visited[name] = true
 				local ok, err = pcall(resolve_one, name)
 				if not ok then
-					collector.mark(type(name) == "string" and name or tostring(name), strip_position(err))
+					collector.mark(name, strip_position(err))
 				end
 			end
 		end
@@ -579,10 +589,7 @@ function M.resolve(spec)
 			end
 			settled = true
 			for _, name in ipairs(spec.deps) do
-				collector.mark(
-					type(name) == "string" and name or tostring(name),
-					"Mason registry refresh did not complete (cannot resolve or install)"
-				)
+				collector.mark(name, "Mason registry refresh did not complete (cannot resolve or install)")
 			end
 			collector.done()
 		end, 300000)

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -32,7 +32,11 @@ function M.any_executable(names)
 	if type(names) ~= "table" then
 		return false
 	end
-	for _, name in ipairs(names) do
+	-- Iterate to maxn, not ipairs: ipairs stops at the first nil, so a sparse
+	-- list (e.g. `{ cond and "foo" or nil, "bar" }`) would silently truncate the
+	-- search and misclassify an available tool as missing.
+	for i = 1, table.maxn(names) do
+		local name = names[i]
 		if type(name) == "string" and name ~= "" and vim.fn.executable(name) == 1 then
 			return true
 		end
@@ -57,7 +61,10 @@ function M.find_executable(names)
 	if type(names) ~= "table" then
 		return nil
 	end
-	for _, name in ipairs(names) do
+	-- maxn, not ipairs — see any_executable: a nil hole must not end the probe.
+	local last = table.maxn(names)
+	for i = 1, last do
+		local name = names[i]
 		if type(name) == "string" and name ~= "" then
 			local path = vim.fn.exepath(name)
 			if path ~= "" then
@@ -67,7 +74,8 @@ function M.find_executable(names)
 	end
 	local root = M.mason_root()
 	if root then
-		for _, name in ipairs(names) do
+		for i = 1, last do
+			local name = names[i]
 			if type(name) == "string" and name ~= "" then
 				-- exepath() on an absolute candidate validates executability and resolves
 				-- the extension on Windows (mason bin shims are `<name>.cmd` there).
@@ -99,10 +107,12 @@ function M.exepath_or_error(names, hint)
 	end
 	-- Render only well-formed entries (find_executable skipped the rest):
 	-- table.concat throws on tables/booleans/nil holes, which would replace the
-	-- actionable message below with an unrelated concat error.
+	-- actionable message below with an unrelated concat error. maxn, not ipairs,
+	-- so entries after a nil hole still render (matching the probe above).
 	local shown = {}
 	if type(names) == "table" then
-		for _, name in ipairs(names) do
+		for i = 1, table.maxn(names) do
+			local name = names[i]
 			if type(name) == "string" and name ~= "" then
 				shown[#shown + 1] = name
 			end

--- a/lua/modules/utils/tools.lua
+++ b/lua/modules/utils/tools.lua
@@ -1,0 +1,420 @@
+-- Discovery-first tool resolution helpers (RFC: #1293).
+--
+-- Treat Mason as one *installer backend* rather than a hard requirement. For
+-- every external tool (LSP server, formatter/linter source, DAP adapter) the
+-- resolution order is: already on $PATH (system / Mason) → installable via
+-- Mason → otherwise surfaced to the user. These helpers provide the shared
+-- $PATH check, a per-subsystem warning aggregator, and a single resolution loop
+-- (`M.resolve`) so "please install this yourself" is reported once, not once per
+-- missing tool, and all three subsystems share one refresh-aware,
+-- install-then-configure, self-validating code path.
+local M = {}
+
+-- Cross-subsystem install de-duplication. A single Mason package can back more
+-- than one desired tool (e.g. a tool that is both an LSP server and a null-ls
+-- source). Without this, two subsystems racing to install the same package trip
+-- mason's `assert(not self:is_installing())`. Keyed by package name -> the
+-- in-flight install handle, cleared when that install closes.
+---@type table<string, table>
+local installing = {}
+
+---Return true if any of the given executable names is found on $PATH.
+---@param names string|string[] @A single executable name or a list of them.
+---@return boolean
+function M.any_executable(names)
+	if type(names) == "string" then
+		names = { names }
+	end
+	if type(names) ~= "table" then
+		return false
+	end
+	for _, name in ipairs(names) do
+		if type(name) == "string" and name ~= "" and vim.fn.executable(name) == 1 then
+			return true
+		end
+	end
+	return false
+end
+
+---Create a collector that aggregates tools which could not be set up automatically
+---into a single deferred warning. This avoids spamming one notification per tool.
+---Entries fall into two classes, rendered as separate sections so the guidance
+---matches the cause:
+---  * `mark`         — a tool that couldn't be set up: not available (install it /
+---                     put it on $PATH) or its configuration failed. An optional
+---                     `reason` is rendered inline so config-time `error()`
+---                     messages from client/server configs are surfaced.
+---  * `mark_unknown` — a configured name we don't recognize (likely a typo, or an
+---                     outdated or unsupported name; may be a package, server,
+---                     adapter, or source name); the fix is to correct the config,
+---                     not a manual install.
+---
+---Usage:
+---  local c = tools.missing_collector("LSP")
+---  c.mark("dartls")                            -- unresolved tool (sync)
+---  c.mark("delve", "dlv not found on $PATH")   -- unresolved tool with reason
+---  c.mark_unknown("gpls")                      -- unknown / typo'd name (sync)
+---  c.track(pkg, "gopls", recheck, on_ready)    -- async install; recheck() => available?
+---  c.done()                                    -- flush (handles the no-async case)
+---@param title string @Notification title identifying the subsystem.
+---@return { mark: fun(name: string, reason?: string), mark_unknown: fun(name: string), track: fun(pkg, name, recheck, on_ready?), done: fun() }
+function M.missing_collector(title)
+	local missing = {}
+	local reasons = {}
+	local unknown = {}
+	local queued = {}
+	local seen = {}
+	local pending = 0
+	local flushed = false
+
+	-- Record a name into a bucket once: ignore non-strings/empties and de-duplicate
+	-- (across both buckets) so the aggregated notification stays stable regardless
+	-- of how callers invoke it.
+	local function record(bucket, name)
+		if type(name) ~= "string" or name == "" or seen[name] then
+			return false
+		end
+		seen[name] = true
+		bucket[#bucket + 1] = name
+		return true
+	end
+	local function add(name, reason)
+		if record(missing, name) and type(reason) == "string" and reason ~= "" then
+			reasons[name] = reason
+		end
+	end
+	local function add_unknown(name)
+		record(unknown, name)
+	end
+
+	local function render(name)
+		local reason = reasons[name]
+		return reason and (name .. " — " .. reason) or name
+	end
+
+	local function flush()
+		if flushed or pending > 0 then
+			return
+		end
+		flushed = true
+		if #missing == 0 and #unknown == 0 then
+			return
+		end
+		local sections = {}
+		if #missing > 0 then
+			table.sort(missing)
+			local lines = {}
+			for _, name in ipairs(missing) do
+				lines[#lines + 1] = render(name)
+			end
+			sections[#sections + 1] = "The following tools could not be set up automatically.\n"
+				.. "Install them / ensure they are on $PATH, or check their configuration\n"
+				.. "for errors:\n  • "
+				.. table.concat(lines, "\n  • ")
+		end
+		if #unknown > 0 then
+			table.sort(unknown)
+			sections[#sections + 1] = "The following names are not recognized (likely a typo, or an outdated\n"
+				.. "or unsupported name) — correct or remove them from your config:\n  • "
+				.. table.concat(unknown, "\n  • ")
+		end
+		local message = table.concat(sections, "\n\n")
+		vim.schedule(function()
+			vim.notify(message, vim.log.levels.WARN, { title = title })
+		end)
+	end
+
+	return {
+		---Record a tool that could not be resolved (not installable / not confirmed).
+		---An optional `reason` (e.g. a config `error()` message) is rendered inline.
+		mark = add,
+		---Record a configured name we don't recognize (typo / outdated / unsupported).
+		mark_unknown = add_unknown,
+		---Track an async Mason install for `pkg`; `recheck()` must report final
+		---availability and `on_ready()` (optional) reconfigures the tool on success.
+		---Guards:
+		---  * If the package is already installing (another subsystem this session,
+		---    or a manual/prior Mason install), attach to the existing handle instead
+		---    of calling `pkg:install()` again (which would trip mason's
+		---    "already installing" assert) and don't mis-mark it missing.
+		---  * If `pkg:install()` errors or returns a handle without `:once`, the tool
+		---    is recorded as missing instead of aborting the caller's loop.
+		track = function(pkg, name, recheck, on_ready)
+			local pkg_name = type(pkg) == "table" and pkg.name or nil
+			local handle = pkg_name and installing[pkg_name] or nil
+
+			-- Already being installed elsewhere: reuse its handle so we still run
+			-- recheck()/on_ready() when it finishes, without starting a duplicate
+			-- install. Covers cross-subsystem shared packages and manual/prior installs.
+			if not handle and type(pkg.is_installing) == "function" then
+				local ok_ing, is_ing = pcall(function()
+					return pkg:is_installing()
+				end)
+				if ok_ing and is_ing and type(pkg.get_install_handle) == "function" then
+					local ok_h, opt = pcall(function()
+						return pkg:get_install_handle()
+					end)
+					if ok_h and type(opt) == "table" and type(opt.if_present) == "function" then
+						opt:if_present(function(h)
+							handle = h
+						end)
+					end
+				end
+			end
+
+			if not handle then
+				local ok, h = pcall(function()
+					return pkg:install()
+				end)
+				if not ok or type(h) ~= "table" or type(h.once) ~= "function" then
+					add(name)
+					return
+				end
+				handle = h
+				if pkg_name then
+					installing[pkg_name] = handle
+				end
+			elseif type(handle.once) ~= "function" then
+				-- Shared handle isn't usable (unexpected shape); mark rather than hang.
+				add(name)
+				return
+			end
+
+			pending = pending + 1
+			-- Only queue a real string for the aggregated INFO: a non-string name (a
+			-- misconfigured deps entry) would make done()'s table.sort(queued) error and
+			-- suppress both notifications. Track whether we appended so the throw path
+			-- below pops the right entry.
+			local queued_here = type(name) == "string" and name ~= ""
+			if queued_here then
+				queued[#queued + 1] = name
+			end
+			-- Mason fires "closed" from a luv callback (fast event context) where
+			-- Vim APIs used by recheck()/on_ready() are unsafe; run the handler on the
+			-- main loop via vim.schedule_wrap. Both are pcall'd and pending is
+			-- decremented unconditionally so a throwing callback can't leave pending
+			-- stuck > 0 and permanently suppress the aggregated warning.
+			local registered = pcall(
+				handle.once,
+				handle,
+				"closed",
+				vim.schedule_wrap(function()
+					if pkg_name then
+						installing[pkg_name] = nil
+					end
+					local rc_ok, available = pcall(recheck)
+					if rc_ok and available then
+						if type(on_ready) == "function" then
+							pcall(on_ready)
+						end
+					else
+						add(name)
+					end
+					pending = pending - 1
+					flush()
+				end)
+			)
+			-- If once() itself threw, no decrementing callback ever attached; undo the
+			-- accounting so a failed registration can't leave pending > 0 (which would
+			-- permanently suppress the aggregated warning). Drop the cached handle too,
+			-- or later resolutions would reuse it forever (never retrying the install).
+			if not registered then
+				pending = pending - 1
+				if queued_here then
+					queued[#queued] = nil
+				end
+				if pkg_name then
+					installing[pkg_name] = nil
+				end
+				add(name)
+			end
+		end,
+		---Flush the aggregated warning once all tracked installs have settled.
+		done = function()
+			-- One aggregated INFO (not one-per-tool) so a first launch shows progress
+			-- and a "relaunch" hint instead of silently downloading in the background.
+			if #queued > 0 then
+				table.sort(queued)
+				local message = string.format(
+					"Installing %d tool(s) via Mason in the background; each is configured\n"
+						.. "automatically once its install finishes (relaunch if one isn't picked up):\n  • %s",
+					#queued,
+					table.concat(queued, "\n  • ")
+				)
+				vim.schedule(function()
+					vim.notify(message, vim.log.levels.INFO, { title = title })
+				end)
+			end
+			flush()
+		end,
+	}
+end
+
+---Collect the executable name(s) a Mason package provides, from its spec.
+---Falls back to the package name when the spec declares no `bin` table.
+---@param pkg table @A mason-registry Package object.
+---@param fallback string @Name to use when `pkg.spec.bin` is absent.
+---@return string[]
+function M.package_binaries(pkg, fallback)
+	local bins = {}
+	if type(pkg.spec) == "table" and type(pkg.spec.bin) == "table" then
+		for bin_name, _ in pairs(pkg.spec.bin) do
+			bins[#bins + 1] = bin_name
+		end
+	end
+	if #bins == 0 then
+		bins = { fallback }
+	end
+	return bins
+end
+
+---Mason's package install root, or nil when Mason isn't available. Prefers the
+---settings API (authoritative and present as soon as mason is required) over the
+---`$MASON` env var, which is only set as a side effect of `mason.setup()` and may
+---not be exported at all. The resolved root is confirmed to exist on disk so the
+---"nil when Mason is unavailable" contract holds for a fresh (never-bootstrapped)
+---setup, where the setting/env may point at a directory that isn't there yet.
+---@return string|nil
+function M.mason_root()
+	local root
+	local ok, settings = pcall(require, "mason.settings")
+	if ok and settings.current and type(settings.current.install_root_dir) == "string" then
+		root = settings.current.install_root_dir
+	else
+		root = vim.env.MASON
+	end
+	if type(root) == "string" and root ~= "" and vim.uv.fs_stat(root) then
+		return root
+	end
+	return nil
+end
+
+---Shared discovery-first resolution loop for a subsystem's desired tools.
+---
+---For each entry in `spec.deps` the resolution order is:
+---  0. Unrecognized name (`unknown_of`)          -> ask the user to fix the config
+---     (a null-ls source with no matching builtin, say); never install.
+---  1. Available now (Mason-installed or a binary on $PATH) -> configure now.
+---  2. Not available but a Mason package exists   -> install, then configure on
+---     completion (never configured with an unresolved binary).
+---  3. No Mason package but a local config exists -> configure now; the
+---     client/server config self-validates its binary and `error()`s if absent,
+---     surfaced (with the message) as missing. A pure-Lua null-ls builtin (no
+---     external binary) also lands here and is registered directly.
+---  4. Otherwise                                  -> ask the user to install it
+---     (or `mark_unknown` when the Mason mapping is stale).
+---
+---The whole loop runs inside `registry.refresh(...)` so Mason's package specs /
+---mappings are loaded even on a fresh (never-bootstrapped) setup; without a
+---registry it runs immediately. `configure` is optional (formatters/linters just
+---install-or-warn) and is always pcall'd so one failing setup can't abort the rest.
+---@param spec {
+---  title: string,
+---  deps: string[],
+---  registry: table|nil,
+---  package_of: fun(name: string): string|nil,
+---  binaries_of: fun(name: string, pkg: table|nil): string[],
+---  unknown_of?: fun(name: string): boolean,
+---  has_local_config?: fun(name: string): boolean,
+---  configure?: fun(name: string),
+---}
+function M.resolve(spec)
+	local collector = M.missing_collector(spec.title)
+	local registry = spec.registry
+
+	-- Configure one tool, surfacing a config-time error (e.g. a client config that
+	-- can't find its binary) as a missing entry annotated with the error message.
+	local function do_configure(name)
+		if type(spec.configure) ~= "function" then
+			return
+		end
+		local ok, err = pcall(spec.configure, name)
+		if not ok then
+			local reason
+			if type(err) == "string" then
+				-- Strip Lua's "chunkname:line: " position prefix that `error(msg)` adds,
+				-- so the aggregated warning reads "delve — dlv not found …" rather than
+				-- "delve — …/delve.lua:17: dlv not found …".
+				reason = (err:gsub("^[^\n]-:%d+: ", ""))
+			end
+			collector.mark(name, reason)
+		end
+	end
+
+	local function resolve_one(name)
+		-- Unrecognized name: the fix is to correct the config, not install anything.
+		-- Checked first so a typo is never misreported as a missing/installable tool.
+		if spec.unknown_of and spec.unknown_of(name) then
+			collector.mark_unknown(name)
+			return
+		end
+
+		local pkg_name = spec.package_of(name)
+		local pkg, pkg_unknown = nil, false
+		if pkg_name and registry then
+			local ok, resolved = pcall(registry.get_package, pkg_name)
+			if ok then
+				pkg = resolved
+			else
+				-- Mapping points at a Mason package the registry doesn't have (stale
+				-- mapping / registry skew). Fall through to $PATH / local-config below;
+				-- only if nothing else resolves it do we report the bad mapping.
+				pkg_unknown = true
+			end
+		end
+
+		local binaries = spec.binaries_of(name, pkg)
+		local available = (pkg ~= nil and pkg:is_installed()) or M.any_executable(binaries)
+
+		-- Not available yet but Mason ships a package: install in the background and
+		-- only configure once the binary is available, so an adapter/server is never
+		-- registered with an empty command.
+		if not available and pkg ~= nil then
+			collector.track(pkg, name, function()
+				return pkg:is_installed() or M.any_executable(spec.binaries_of(name, pkg))
+			end, function()
+				do_configure(name)
+			end)
+			return
+		end
+
+		-- Configure now when the tool is available, or when a local config exists: the
+		-- local config is the tool's own discovery-first resolver ($PATH / system /
+		-- venv) and self-validates, `error()`ing when its binary is absent, which
+		-- do_configure surfaces as missing (with the message). A pure-Lua null-ls
+		-- builtin (no binary, `has_local_config` true) is likewise registered here.
+		if available or (spec.has_local_config and spec.has_local_config(name)) then
+			do_configure(name)
+		elseif pkg_unknown then
+			collector.mark_unknown(pkg_name == name and name or (pkg_name .. " (for " .. name .. ")"))
+		else
+			collector.mark(name)
+		end
+	end
+
+	local function run()
+		for _, name in ipairs(spec.deps) do
+			resolve_one(name)
+		end
+		collector.done()
+	end
+
+	if registry and type(registry.refresh) == "function" then
+		-- refresh() calls back synchronously when the cache is fresh (the common
+		-- case) and asynchronously — from a fast event context — when it actually
+		-- updates. Defer to the main loop only in the latter case so synchronous
+		-- resolution (e.g. DAP adapters needed immediately after `:DapContinue`)
+		-- isn't needlessly pushed to the next tick.
+		registry.refresh(function()
+			if vim.in_fast_event() then
+				vim.schedule(run)
+			else
+				run()
+			end
+		end)
+	else
+		run()
+	end
+end
+
+return M


### PR DESCRIPTION
## Summary — RFC [#1293](https://github.com/ayamir/nvimdots/issues/1293)

Implements the "separate tool **discovery** from tool **installation**" idea from [this comment](https://github.com/ayamir/nvimdots/issues/1293#issuecomment-4839368578): Mason becomes one *installer backend*, not a hard runtime gate. On FreeBSD/NixOS/etc. — where Mason's prebuilt binaries may not run — system-provided tools are used directly, with **no manual symlinking and no per-tool startup notification spam**.

**No new setting, no OS detection** — behaviour is driven purely by availability, so existing configs keep working unchanged.

### Resolution model (per tool)

```
1. on $PATH (system / Mason) ─────────► use it
2. not on $PATH, Mason has a package ─► install, use next launch
3. neither ───────────────────────────► aggregate into ONE "please install" warning
```

The key change is that **configuration/registration is no longer gated on Mason's *installed* set** — today LSP (`mason-lspconfig`), DAP (`mason-nvim-dap`), and formatters/linters (`mason-null-ls` `automatic_setup`) all iterate `get_installed_package_names()`, so a Mason-less machine configures nothing even when the tools exist on `$PATH`.

### Changes

| Area | File | What |
|---|---|---|
| Helper | `modules/utils/tools.lua` (new) | `$PATH` check, Mason `spec.bin` resolver, per-subsystem warning aggregator (one message, not N) |
| LSP | `completion/mason-lspconfig.lua` | Cascade driven by `lsp_deps`; binary probed from the manual spec's `cmd` then nvim-lspconfig's default |
| DAP | `tool/dap/init.lua` | Self-drive over `dap_deps`; install check precedes client-config check so Mason-file-dependent configs (python→debugpy) still install |
| Formatters/Linters | `completion/mason-null-ls.lua` | Register the none-ls builtin for any source that's installed or on `$PATH`; guarded by `null_ls.is_registered` so explicit `null-ls.lua` sources keep custom settings |

All `*_deps` lists keep their shape. The inline `dartls` check in `lsp.lua` moved into `mason-lspconfig.setup` as an automatic injection: `dartls` is added to the resolver's deps whenever the `dart` executable is on `$PATH`, preserving the historical auto-enable while routing it through the shared resolver (an explicit `lsp_deps` entry also works and surfaces the missing-tool warning when `dart` is absent). Mason setups with `PATH = "skip"` are covered too: registered LSP `cmd`s and none-ls builtin commands are rewritten to the absolute path inside Mason's bin dir when the bare name is not executable.

### Verification

- `stylua --check`: clean. Reviewed against the CI luacheck flags (`--std luajit --max-line-length 150 --globals vim _debugging`): no unused locals, no long lines, no stray globals.
- Probed the real plugin APIs used: `mason-registry.is_installed`, `mason-lspconfig` `lspconfig_to_package`, `vim.lsp.config[name].cmd[1]`, `mason-nvim-dap.mappings.*`, `pkg.spec.bin`.
- Verified the none-ls path against `none-ls` + `mason-null-ls` (pinned to this repo's lockfile commits): every `null_ls_deps` source resolves to a builtin + binary (`clang_format`→`clang-format`) + Mason package, and `null_ls.register`/`is_registered` dedup works.

### Notes / limitations
- DAP `$PATH` detection relies on the Mason package's declared binaries (nvim-dap has no uniform command registry); adapters with a client config resolve their own binary via `vim.fn.exepath`.
- A server whose nvim-lspconfig `cmd` is a function (rare) can't be `$PATH`-probed and falls back to the Mason-package check.
- Not yet exercised on an actual BSD/NixOS host — that's the real-world validation step. Feedback from users on those platforms welcome.

This mirrors a change I've been running on my fork; opening here per the RFC discussion.
